### PR TITLE
feat: adicionar estrutura de usuario e treinos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,10 +135,6 @@
             <version>2.1.29</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-envers</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.17.2</version>

--- a/src/main/java/com/example/demo/controller/AcademiaController.java
+++ b/src/main/java/com/example/demo/controller/AcademiaController.java
@@ -1,0 +1,32 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.AcademiaDTO;
+import com.example.demo.dto.ApiResponse;
+import com.example.demo.service.AcademiaService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/academias")
+public class AcademiaController {
+    private final AcademiaService service;
+
+    public AcademiaController(AcademiaService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> criar(@Validated @RequestBody AcademiaDTO dto) {
+        String msg = service.create(dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<AcademiaDTO>>> listar(Pageable pageable) {
+        Page<AcademiaDTO> page = service.findAll(pageable);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Lista de academias", page, null));
+    }
+}

--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -1,9 +1,6 @@
 package com.example.demo.controller;
 
-import com.example.demo.dto.AlunoDTO;
-import com.example.demo.dto.AlunoMedidaDTO;
-import com.example.demo.dto.AlunoObservacaoDTO;
-import com.example.demo.dto.ApiResponse;
+import com.example.demo.dto.*;
 import com.example.demo.service.AlunoMedidaService;
 import com.example.demo.service.AlunoObservacaoService;
 import com.example.demo.service.AlunoService;
@@ -32,9 +29,9 @@ public class AlunoController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<AlunoDTO>> criar(@Validated @RequestBody AlunoDTO dto) {
-        AlunoDTO salvo = service.create(dto);
-        return ResponseEntity.ok(new ApiResponse<>(true, "Aluno criado com sucesso", salvo, null));
+    public ResponseEntity<ApiResponse<String>> criar(@Validated @RequestBody AlunoDTO dto) {
+        String msg = service.create(dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
     @GetMapping
@@ -50,9 +47,9 @@ public class AlunoController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<AlunoDTO>> atualizar(@PathVariable Long id, @Validated @RequestBody AlunoDTO dto) {
-        AlunoDTO atualizado = service.update(id, dto);
-        return ResponseEntity.ok(new ApiResponse<>(true, "Aluno atualizado", atualizado, null));
+    public ResponseEntity<ApiResponse<String>> atualizar(@PathVariable Long id, @Validated @RequestBody AlunoDTO dto) {
+        String msg = service.update(id, dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/example/demo/controller/ExercicioController.java
+++ b/src/main/java/com/example/demo/controller/ExercicioController.java
@@ -1,0 +1,32 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.ApiResponse;
+import com.example.demo.dto.ExercicioDTO;
+import com.example.demo.service.ExercicioService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/exercicios")
+public class ExercicioController {
+    private final ExercicioService service;
+
+    public ExercicioController(ExercicioService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> criar(@Validated @RequestBody ExercicioDTO dto) {
+        String msg = service.create(dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<ExercicioDTO>>> listar(Pageable pageable) {
+        Page<ExercicioDTO> page = service.findAll(pageable);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Lista de exercícios", page, null));
+    }
+}

--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -1,0 +1,32 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.ApiResponse;
+import com.example.demo.dto.FichaTreinoDTO;
+import com.example.demo.service.FichaTreinoService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/fichas")
+public class FichaTreinoController {
+    private final FichaTreinoService service;
+
+    public FichaTreinoController(FichaTreinoService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> criar(@Validated @RequestBody FichaTreinoDTO dto) {
+        String msg = service.create(dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<FichaTreinoDTO>>> listar(Pageable pageable) {
+        Page<FichaTreinoDTO> page = service.findAll(pageable);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Lista de fichas de treino", page, null));
+    }
+}

--- a/src/main/java/com/example/demo/controller/ProfessorController.java
+++ b/src/main/java/com/example/demo/controller/ProfessorController.java
@@ -1,0 +1,50 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.ApiResponse;
+import com.example.demo.dto.ProfessorDTO;
+import com.example.demo.service.ProfessorService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/professores")
+public class ProfessorController {
+    private final ProfessorService service;
+
+    public ProfessorController(ProfessorService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> criar(@Validated @RequestBody ProfessorDTO dto) {
+        String msg = service.create(dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<ProfessorDTO>>> listar(Pageable pageable) {
+        Page<ProfessorDTO> page = service.findAll(pageable);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Lista de professores", page, null));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ProfessorDTO>> buscar(@PathVariable Long id) {
+        ProfessorDTO dto = service.findById(id);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Professor encontrado", dto, null));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<String>> atualizar(@PathVariable Long id, @Validated @RequestBody ProfessorDTO dto) {
+        String msg = service.update(id, dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> remover(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Professor removido", null, null));
+    }
+}

--- a/src/main/java/com/example/demo/dto/AcademiaDTO.java
+++ b/src/main/java/com/example/demo/dto/AcademiaDTO.java
@@ -1,0 +1,31 @@
+package com.example.demo.dto;
+
+public class AcademiaDTO {
+    private Long id;
+    private String nome;
+    private UsuarioDTO admin;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public UsuarioDTO getAdmin() {
+        return admin;
+    }
+
+    public void setAdmin(UsuarioDTO admin) {
+        this.admin = admin;
+    }
+}

--- a/src/main/java/com/example/demo/dto/AlunoDTO.java
+++ b/src/main/java/com/example/demo/dto/AlunoDTO.java
@@ -3,83 +3,11 @@ package com.example.demo.dto;
 import com.example.demo.entity.StatusAluno;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
-public class AlunoDTO {
-    private Long id;
-    private UUID uuid;
-    private String nome;
-    private String cpf;
-    private LocalDate dataNascimento;
-    private String telefone;
-    private String email;
-    private String enderecoCompleto;
+public class AlunoDTO extends UsuarioDTO {
     private LocalDate dataMatricula;
     private StatusAluno status;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public UUID getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(UUID uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getNome() {
-        return nome;
-    }
-
-    public void setNome(String nome) {
-        this.nome = nome;
-    }
-
-    public String getCpf() {
-        return cpf;
-    }
-
-    public void setCpf(String cpf) {
-        this.cpf = cpf;
-    }
-
-    public LocalDate getDataNascimento() {
-        return dataNascimento;
-    }
-
-    public void setDataNascimento(LocalDate dataNascimento) {
-        this.dataNascimento = dataNascimento;
-    }
-
-    public String getTelefone() {
-        return telefone;
-    }
-
-    public void setTelefone(String telefone) {
-        this.telefone = telefone;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getEnderecoCompleto() {
-        return enderecoCompleto;
-    }
-
-    public void setEnderecoCompleto(String enderecoCompleto) {
-        this.enderecoCompleto = enderecoCompleto;
-    }
+    private Long professorId;
 
     public LocalDate getDataMatricula() {
         return dataMatricula;
@@ -95,5 +23,13 @@ public class AlunoDTO {
 
     public void setStatus(StatusAluno status) {
         this.status = status;
+    }
+
+    public Long getProfessorId() {
+        return professorId;
+    }
+
+    public void setProfessorId(Long professorId) {
+        this.professorId = professorId;
     }
 }

--- a/src/main/java/com/example/demo/dto/ExercicioDTO.java
+++ b/src/main/java/com/example/demo/dto/ExercicioDTO.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto;
+
+public class ExercicioDTO {
+    private Long id;
+    private String nome;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+}

--- a/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
@@ -1,0 +1,42 @@
+package com.example.demo.dto;
+
+import java.util.List;
+
+public class FichaTreinoDTO {
+    private Long id;
+    private Long alunoId;
+    private Long professorId;
+    private List<Long> exerciciosIds;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getAlunoId() {
+        return alunoId;
+    }
+
+    public void setAlunoId(Long alunoId) {
+        this.alunoId = alunoId;
+    }
+
+    public Long getProfessorId() {
+        return professorId;
+    }
+
+    public void setProfessorId(Long professorId) {
+        this.professorId = professorId;
+    }
+
+    public List<Long> getExerciciosIds() {
+        return exerciciosIds;
+    }
+
+    public void setExerciciosIds(List<Long> exerciciosIds) {
+        this.exerciciosIds = exerciciosIds;
+    }
+}

--- a/src/main/java/com/example/demo/dto/ProfessorDTO.java
+++ b/src/main/java/com/example/demo/dto/ProfessorDTO.java
@@ -1,0 +1,4 @@
+package com.example.demo.dto;
+
+public class ProfessorDTO extends UsuarioDTO {
+}

--- a/src/main/java/com/example/demo/dto/UsuarioDTO.java
+++ b/src/main/java/com/example/demo/dto/UsuarioDTO.java
@@ -1,0 +1,79 @@
+package com.example.demo.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class UsuarioDTO {
+    private Long id;
+    private UUID uuid;
+    private String nome;
+    private String cpf;
+    private LocalDate dataNascimento;
+    private String telefone;
+    private String email;
+    private String enderecoCompleto;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(String cpf) {
+        this.cpf = cpf;
+    }
+
+    public LocalDate getDataNascimento() {
+        return dataNascimento;
+    }
+
+    public void setDataNascimento(LocalDate dataNascimento) {
+        this.dataNascimento = dataNascimento;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getEnderecoCompleto() {
+        return enderecoCompleto;
+    }
+
+    public void setEnderecoCompleto(String enderecoCompleto) {
+        this.enderecoCompleto = enderecoCompleto;
+    }
+}

--- a/src/main/java/com/example/demo/entity/Academia.java
+++ b/src/main/java/com/example/demo/entity/Academia.java
@@ -1,0 +1,19 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class Academia {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nome;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "admin_id", nullable = false)
+    private Usuario admin;
+}

--- a/src/main/java/com/example/demo/entity/Aluno.java
+++ b/src/main/java/com/example/demo/entity/Aluno.java
@@ -2,45 +2,19 @@ package com.example.demo.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Data
 @Entity
-public class Aluno {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+@DiscriminatorValue("ALUNO")
+public class Aluno extends Usuario {
+    @ManyToOne
+    @JoinColumn(name = "professor_id")
+    private Professor professor;
 
-    @Column(nullable = false, unique = true, updatable = false)
-    private UUID uuid = UUID.randomUUID();
-
-    @Column(nullable = false)
-    private String nome;
-
-    @Column(nullable = false, unique = true)
-    private String cpf;
-
-    private LocalDate dataNascimento;
-    private String telefone;
-
-    @Column(unique = true)
-    private String email;
-
-    private String enderecoCompleto;
     private LocalDate dataMatricula;
 
     @Enumerated(EnumType.STRING)
     private StatusAluno status = StatusAluno.ATIVO;
-
-    @CreationTimestamp
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/demo/entity/Exercicio.java
+++ b/src/main/java/com/example/demo/entity/Exercicio.java
@@ -1,0 +1,15 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class Exercicio {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String nome;
+}

--- a/src/main/java/com/example/demo/entity/FichaTreino.java
+++ b/src/main/java/com/example/demo/entity/FichaTreino.java
@@ -1,0 +1,27 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Entity
+public class FichaTreino {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Aluno aluno;
+
+    @ManyToOne
+    private Professor professor;
+
+    @ManyToMany
+    @JoinTable(name = "ficha_exercicio",
+            joinColumns = @JoinColumn(name = "ficha_id"),
+            inverseJoinColumns = @JoinColumn(name = "exercicio_id"))
+    private List<Exercicio> exercicios = new ArrayList<>();
+}

--- a/src/main/java/com/example/demo/entity/Professor.java
+++ b/src/main/java/com/example/demo/entity/Professor.java
@@ -1,0 +1,11 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Data;
+
+@Data
+@Entity
+@DiscriminatorValue("PROFESSOR")
+public class Professor extends Usuario {
+}

--- a/src/main/java/com/example/demo/entity/Usuario.java
+++ b/src/main/java/com/example/demo/entity/Usuario.java
@@ -1,0 +1,44 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "tipo")
+public class Usuario {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID uuid = UUID.randomUUID();
+
+    @Column(nullable = false)
+    private String nome;
+
+    @Column(nullable = false, unique = true)
+    private String cpf;
+
+    private LocalDate dataNascimento;
+    private String telefone;
+
+    @Column(unique = true)
+    private String email;
+
+    private String enderecoCompleto;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/demo/mapper/AcademiaMapper.java
+++ b/src/main/java/com/example/demo/mapper/AcademiaMapper.java
@@ -1,0 +1,23 @@
+package com.example.demo.mapper;
+
+import com.example.demo.dto.AcademiaDTO;
+import com.example.demo.entity.Academia;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AcademiaMapper {
+    private final ModelMapper mapper;
+
+    public AcademiaMapper(ModelMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public AcademiaDTO toDto(Academia academia) {
+        return mapper.map(academia, AcademiaDTO.class);
+    }
+
+    public Academia toEntity(AcademiaDTO dto) {
+        return mapper.map(dto, Academia.class);
+    }
+}

--- a/src/main/java/com/example/demo/mapper/AlunoMapper.java
+++ b/src/main/java/com/example/demo/mapper/AlunoMapper.java
@@ -14,7 +14,11 @@ public class AlunoMapper {
     }
 
     public AlunoDTO toDto(Aluno aluno) {
-        return mapper.map(aluno, AlunoDTO.class);
+        AlunoDTO dto = mapper.map(aluno, AlunoDTO.class);
+        if (aluno.getProfessor() != null) {
+            dto.setProfessorId(aluno.getProfessor().getId());
+        }
+        return dto;
     }
 
     public Aluno toEntity(AlunoDTO dto) {

--- a/src/main/java/com/example/demo/mapper/ExercicioMapper.java
+++ b/src/main/java/com/example/demo/mapper/ExercicioMapper.java
@@ -1,0 +1,23 @@
+package com.example.demo.mapper;
+
+import com.example.demo.dto.ExercicioDTO;
+import com.example.demo.entity.Exercicio;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExercicioMapper {
+    private final ModelMapper mapper;
+
+    public ExercicioMapper(ModelMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public ExercicioDTO toDto(Exercicio exercicio) {
+        return mapper.map(exercicio, ExercicioDTO.class);
+    }
+
+    public Exercicio toEntity(ExercicioDTO dto) {
+        return mapper.map(dto, Exercicio.class);
+    }
+}

--- a/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
+++ b/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
@@ -1,0 +1,33 @@
+package com.example.demo.mapper;
+
+import com.example.demo.dto.FichaTreinoDTO;
+import com.example.demo.entity.Exercicio;
+import com.example.demo.entity.FichaTreino;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+@Component
+public class FichaTreinoMapper {
+    private final ModelMapper mapper;
+
+    public FichaTreinoMapper(ModelMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public FichaTreinoDTO toDto(FichaTreino ficha) {
+        FichaTreinoDTO dto = new FichaTreinoDTO();
+        dto.setId(ficha.getId());
+        dto.setAlunoId(ficha.getAluno().getId());
+        if (ficha.getProfessor() != null) {
+            dto.setProfessorId(ficha.getProfessor().getId());
+        }
+        dto.setExerciciosIds(ficha.getExercicios().stream().map(Exercicio::getId).collect(Collectors.toList()));
+        return dto;
+    }
+
+    public FichaTreino toEntity(FichaTreinoDTO dto) {
+        return mapper.map(dto, FichaTreino.class);
+    }
+}

--- a/src/main/java/com/example/demo/mapper/ProfessorMapper.java
+++ b/src/main/java/com/example/demo/mapper/ProfessorMapper.java
@@ -1,0 +1,23 @@
+package com.example.demo.mapper;
+
+import com.example.demo.dto.ProfessorDTO;
+import com.example.demo.entity.Professor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfessorMapper {
+    private final ModelMapper mapper;
+
+    public ProfessorMapper(ModelMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public ProfessorDTO toDto(Professor professor) {
+        return mapper.map(professor, ProfessorDTO.class);
+    }
+
+    public Professor toEntity(ProfessorDTO dto) {
+        return mapper.map(dto, Professor.class);
+    }
+}

--- a/src/main/java/com/example/demo/repository/AcademiaRepository.java
+++ b/src/main/java/com/example/demo/repository/AcademiaRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Academia;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AcademiaRepository extends JpaRepository<Academia, Long> {
+}

--- a/src/main/java/com/example/demo/repository/ExercicioRepository.java
+++ b/src/main/java/com/example/demo/repository/ExercicioRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Exercicio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExercicioRepository extends JpaRepository<Exercicio, Long> {
+}

--- a/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
+++ b/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.FichaTreino;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FichaTreinoRepository extends JpaRepository<FichaTreino, Long> {
+}

--- a/src/main/java/com/example/demo/repository/ProfessorRepository.java
+++ b/src/main/java/com/example/demo/repository/ProfessorRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Professor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfessorRepository extends JpaRepository<Professor, Long> {
+}

--- a/src/main/java/com/example/demo/service/AcademiaService.java
+++ b/src/main/java/com/example/demo/service/AcademiaService.java
@@ -1,0 +1,30 @@
+package com.example.demo.service;
+
+import com.example.demo.dto.AcademiaDTO;
+import com.example.demo.entity.Academia;
+import com.example.demo.mapper.AcademiaMapper;
+import com.example.demo.repository.AcademiaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AcademiaService {
+    private final AcademiaRepository repository;
+    private final AcademiaMapper mapper;
+
+    public AcademiaService(AcademiaRepository repository, AcademiaMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    public String create(AcademiaDTO dto) {
+        Academia entity = mapper.toEntity(dto);
+        repository.save(entity);
+        return "Academia criada com sucesso";
+    }
+
+    public Page<AcademiaDTO> findAll(Pageable pageable) {
+        return repository.findAll(pageable).map(mapper::toDto);
+    }
+}

--- a/src/main/java/com/example/demo/service/AlunoService.java
+++ b/src/main/java/com/example/demo/service/AlunoService.java
@@ -2,9 +2,11 @@ package com.example.demo.service;
 
 import com.example.demo.dto.AlunoDTO;
 import com.example.demo.entity.Aluno;
+import com.example.demo.entity.Professor;
 import com.example.demo.exception.ApiException;
 import com.example.demo.mapper.AlunoMapper;
 import com.example.demo.repository.AlunoRepository;
+import com.example.demo.repository.ProfessorRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,15 +17,23 @@ import java.util.Optional;
 public class AlunoService {
     private final AlunoRepository repository;
     private final AlunoMapper mapper;
+    private final ProfessorRepository professorRepository;
 
-    public AlunoService(AlunoRepository repository, AlunoMapper mapper) {
+    public AlunoService(AlunoRepository repository, AlunoMapper mapper, ProfessorRepository professorRepository) {
         this.repository = repository;
         this.mapper = mapper;
+        this.professorRepository = professorRepository;
     }
 
-    public AlunoDTO create(AlunoDTO dto) {
+    public String create(AlunoDTO dto) {
         Aluno entity = mapper.toEntity(dto);
-        return mapper.toDto(repository.save(entity));
+        if (dto.getProfessorId() != null) {
+            Professor professor = professorRepository.findById(dto.getProfessorId())
+                    .orElseThrow(() -> new ApiException("Professor não encontrado"));
+            entity.setProfessor(professor);
+        }
+        repository.save(entity);
+        return "Aluno criado com sucesso";
     }
 
     public Page<AlunoDTO> findAll(Pageable pageable) {
@@ -35,7 +45,7 @@ public class AlunoService {
         return mapper.toDto(entity);
     }
 
-    public AlunoDTO update(Long id, AlunoDTO dto) {
+    public String update(Long id, AlunoDTO dto) {
         Optional<Aluno> opt = repository.findById(id);
         if (opt.isEmpty()) {
             throw new ApiException("Aluno não encontrado");
@@ -49,7 +59,15 @@ public class AlunoService {
         entity.setEnderecoCompleto(dto.getEnderecoCompleto());
         entity.setDataMatricula(dto.getDataMatricula());
         entity.setStatus(dto.getStatus());
-        return mapper.toDto(repository.save(entity));
+        if (dto.getProfessorId() != null) {
+            Professor professor = professorRepository.findById(dto.getProfessorId())
+                    .orElseThrow(() -> new ApiException("Professor não encontrado"));
+            entity.setProfessor(professor);
+        } else {
+            entity.setProfessor(null);
+        }
+        repository.save(entity);
+        return "Aluno atualizado";
     }
 
     public void delete(Long id) {

--- a/src/main/java/com/example/demo/service/ExercicioService.java
+++ b/src/main/java/com/example/demo/service/ExercicioService.java
@@ -1,0 +1,30 @@
+package com.example.demo.service;
+
+import com.example.demo.dto.ExercicioDTO;
+import com.example.demo.entity.Exercicio;
+import com.example.demo.mapper.ExercicioMapper;
+import com.example.demo.repository.ExercicioRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ExercicioService {
+    private final ExercicioRepository repository;
+    private final ExercicioMapper mapper;
+
+    public ExercicioService(ExercicioRepository repository, ExercicioMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    public String create(ExercicioDTO dto) {
+        Exercicio entity = mapper.toEntity(dto);
+        repository.save(entity);
+        return "Exercício criado com sucesso";
+    }
+
+    public Page<ExercicioDTO> findAll(Pageable pageable) {
+        return repository.findAll(pageable).map(mapper::toDto);
+    }
+}

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -1,0 +1,57 @@
+package com.example.demo.service;
+
+import com.example.demo.dto.FichaTreinoDTO;
+import com.example.demo.entity.Aluno;
+import com.example.demo.entity.Exercicio;
+import com.example.demo.entity.FichaTreino;
+import com.example.demo.entity.Professor;
+import com.example.demo.exception.ApiException;
+import com.example.demo.mapper.FichaTreinoMapper;
+import com.example.demo.repository.AlunoRepository;
+import com.example.demo.repository.ExercicioRepository;
+import com.example.demo.repository.FichaTreinoRepository;
+import com.example.demo.repository.ProfessorRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FichaTreinoService {
+    private final FichaTreinoRepository repository;
+    private final FichaTreinoMapper mapper;
+    private final AlunoRepository alunoRepository;
+    private final ProfessorRepository professorRepository;
+    private final ExercicioRepository exercicioRepository;
+
+    public FichaTreinoService(FichaTreinoRepository repository, FichaTreinoMapper mapper,
+                              AlunoRepository alunoRepository, ProfessorRepository professorRepository,
+                              ExercicioRepository exercicioRepository) {
+        this.repository = repository;
+        this.mapper = mapper;
+        this.alunoRepository = alunoRepository;
+        this.professorRepository = professorRepository;
+        this.exercicioRepository = exercicioRepository;
+    }
+
+    public String create(FichaTreinoDTO dto) {
+        FichaTreino ficha = new FichaTreino();
+        Aluno aluno = alunoRepository.findById(dto.getAlunoId())
+                .orElseThrow(() -> new ApiException("Aluno não encontrado"));
+        ficha.setAluno(aluno);
+        if (dto.getProfessorId() != null) {
+            Professor professor = professorRepository.findById(dto.getProfessorId())
+                    .orElseThrow(() -> new ApiException("Professor não encontrado"));
+            ficha.setProfessor(professor);
+        }
+        List<Exercicio> exercicios = exercicioRepository.findAllById(dto.getExerciciosIds());
+        ficha.setExercicios(exercicios);
+        repository.save(ficha);
+        return "Ficha de treino criada com sucesso";
+    }
+
+    public Page<FichaTreinoDTO> findAll(Pageable pageable) {
+        return repository.findAll(pageable).map(mapper::toDto);
+    }
+}

--- a/src/main/java/com/example/demo/service/ProfessorService.java
+++ b/src/main/java/com/example/demo/service/ProfessorService.java
@@ -1,0 +1,53 @@
+package com.example.demo.service;
+
+import com.example.demo.dto.ProfessorDTO;
+import com.example.demo.entity.Professor;
+import com.example.demo.exception.ApiException;
+import com.example.demo.mapper.ProfessorMapper;
+import com.example.demo.repository.ProfessorRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProfessorService {
+    private final ProfessorRepository repository;
+    private final ProfessorMapper mapper;
+
+    public ProfessorService(ProfessorRepository repository, ProfessorMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    public String create(ProfessorDTO dto) {
+        Professor entity = mapper.toEntity(dto);
+        repository.save(entity);
+        return "Professor criado com sucesso";
+    }
+
+    public Page<ProfessorDTO> findAll(Pageable pageable) {
+        return repository.findAll(pageable).map(mapper::toDto);
+    }
+
+    public ProfessorDTO findById(Long id) {
+        Professor entity = repository.findById(id).orElseThrow(() -> new ApiException("Professor não encontrado"));
+        return mapper.toDto(entity);
+    }
+
+    public String update(Long id, ProfessorDTO dto) {
+        Professor entity = repository.findById(id)
+                .orElseThrow(() -> new ApiException("Professor não encontrado"));
+        entity.setNome(dto.getNome());
+        entity.setCpf(dto.getCpf());
+        entity.setDataNascimento(dto.getDataNascimento());
+        entity.setTelefone(dto.getTelefone());
+        entity.setEmail(dto.getEmail());
+        entity.setEnderecoCompleto(dto.getEnderecoCompleto());
+        repository.save(entity);
+        return "Professor atualizado";
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.default_schema=${DB_SCHEME}
-spring.jpa.properties.org.hibernate.envers.audit_table_suffix=_aud
 
 
 # Pool de Conexões (HikariCP - Padrão do Spring Boot)


### PR DESCRIPTION
## Sumário
- remove scripts e dependências de migração/auditoria
- usa herança de tabela única para que Aluno e Professor estendam Usuario
- ajusta DTOs, mapeadores e serviços para o novo modelo

## Testes
- `mvn -q test` *(falhou: Non-resolvable parent POM; Network is unreachable)*
- `apt-get update` *(falhou: The repository is not signed - 403)*

------
https://chatgpt.com/codex/tasks/task_e_689787f9fd488327bbd612dda8c195af