### PR TITLE
Registrar último acesso do usuário no login

### DIFF
--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.demo.controller;
 
 import com.example.demo.common.security.JwtService;
+import com.example.demo.service.UsuarioService;
 import com.example.demo.dto.ApiResponse;
 import com.example.demo.dto.AuthRequest;
 import org.springframework.http.ResponseEntity;
@@ -19,10 +20,12 @@ public class AuthController {
 
     private final AuthenticationManager authenticationManager;
     private final JwtService jwtService;
+    private final UsuarioService usuarioService;
 
-    public AuthController(AuthenticationManager authenticationManager, JwtService jwtService) {
+    public AuthController(AuthenticationManager authenticationManager, JwtService jwtService, UsuarioService usuarioService) {
         this.authenticationManager = authenticationManager;
         this.jwtService = jwtService;
+        this.usuarioService = usuarioService;
     }
 
     @PostMapping("/login")
@@ -31,6 +34,7 @@ public class AuthController {
                 new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
         if (authentication.isAuthenticated()) {
             String token = jwtService.generateToken((UserDetails) authentication.getPrincipal());
+            usuarioService.registrarUltimoAcesso(request.getUsername());
             return ResponseEntity.ok(new ApiResponse<>(true, "Autenticado", token, null));
         }
         return ResponseEntity.status(401)

--- a/src/main/java/com/example/demo/entity/Usuario.java
+++ b/src/main/java/com/example/demo/entity/Usuario.java
@@ -35,6 +35,8 @@ public class Usuario {
 
     private String enderecoCompleto;
 
+    private LocalDateTime ultimoAcesso;
+
     @CreationTimestamp
     @Column(updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/demo/repository/UsuarioRepository.java
+++ b/src/main/java/com/example/demo/repository/UsuarioRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Usuario;
+
+import java.util.Optional;
+
+public interface UsuarioRepository extends BaseRepository<Usuario, Long> {
+    Optional<Usuario> findByCpfOrEmailOrTelefone(String cpf, String email, String telefone);
+}

--- a/src/main/java/com/example/demo/service/UsuarioService.java
+++ b/src/main/java/com/example/demo/service/UsuarioService.java
@@ -1,0 +1,24 @@
+package com.example.demo.service;
+
+import com.example.demo.repository.UsuarioRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class UsuarioService {
+    private final UsuarioRepository repository;
+
+    public UsuarioService(UsuarioRepository repository) {
+        this.repository = repository;
+    }
+
+    public String registrarUltimoAcesso(String login) {
+        return repository.findByCpfOrEmailOrTelefone(login, login, login)
+                .map(usuario -> {
+                    usuario.setUltimoAcesso(LocalDateTime.now());
+                    repository.save(usuario);
+                    return "Último acesso registrado";
+                }).orElse("Usuário não encontrado");
+    }
+}


### PR DESCRIPTION
## Resumo
- Adiciona campo `ultimoAcesso` à entidade `Usuario` para armazenar o horário da última autenticação.
- Inclui `UsuarioService` e `UsuarioRepository` para atualizar o último acesso do usuário.
- Atualiza `AuthController` para registrar o último acesso após login bem-sucedido.

## Testes
- `mvn -q test` *(falhou: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_6897e0ce8bb483279cc7ba6d75b4794f