### PR TITLE
Implementa autenticação com senha criptografada

### DIFF
--- a/src/main/java/com/example/demo/common/config/security/UserAuthenticationConfig.java
+++ b/src/main/java/com/example/demo/common/config/security/UserAuthenticationConfig.java
@@ -8,20 +8,22 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import com.example.demo.repository.UsuarioRepository;
 
 @Configuration
 public class UserAuthenticationConfig {
 
     @Bean
-    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
-        var user = User.withUsername("admin")
-                .password(passwordEncoder.encode("admin"))
-                .roles("USER")
-                .build();
-        return new InMemoryUserDetailsManager(user);
+    public UserDetailsService userDetailsService(UsuarioRepository repository) {
+        return username -> repository.findByEmail(username)
+                .map(usuario -> User.withUsername(usuario.getEmail())
+                        .password(usuario.getSenha())
+                        .roles("USER")
+                        .build())
+                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
     }
 
     @Bean

--- a/src/main/java/com/example/demo/dto/UsuarioDTO.java
+++ b/src/main/java/com/example/demo/dto/UsuarioDTO.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -11,6 +12,8 @@ public class UsuarioDTO {
     private LocalDate dataNascimento;
     private String telefone;
     private String email;
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String senha;
     private String enderecoCompleto;
 
     public Long getId() {
@@ -67,6 +70,14 @@ public class UsuarioDTO {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getSenha() {
+        return senha;
+    }
+
+    public void setSenha(String senha) {
+        this.senha = senha;
     }
 
     public String getEnderecoCompleto() {

--- a/src/main/java/com/example/demo/entity/Usuario.java
+++ b/src/main/java/com/example/demo/entity/Usuario.java
@@ -33,6 +33,9 @@ public class Usuario {
     @Column(unique = true)
     private String email;
 
+    @Column(nullable = false)
+    private String senha;
+
     private String enderecoCompleto;
 
     @CreationTimestamp

--- a/src/main/java/com/example/demo/repository/UsuarioRepository.java
+++ b/src/main/java/com/example/demo/repository/UsuarioRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+    Optional<Usuario> findByEmail(String email);
+}
+

--- a/src/main/java/com/example/demo/service/AlunoService.java
+++ b/src/main/java/com/example/demo/service/AlunoService.java
@@ -10,6 +10,7 @@ import com.example.demo.repository.ProfessorRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
@@ -18,15 +19,18 @@ public class AlunoService {
     private final AlunoRepository repository;
     private final AlunoMapper mapper;
     private final ProfessorRepository professorRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public AlunoService(AlunoRepository repository, AlunoMapper mapper, ProfessorRepository professorRepository) {
+    public AlunoService(AlunoRepository repository, AlunoMapper mapper, ProfessorRepository professorRepository, PasswordEncoder passwordEncoder) {
         this.repository = repository;
         this.mapper = mapper;
         this.professorRepository = professorRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public String create(AlunoDTO dto) {
         Aluno entity = mapper.toEntity(dto);
+        entity.setSenha(passwordEncoder.encode(dto.getSenha()));
         if (dto.getProfessorId() != null) {
             Professor professor = professorRepository.findById(dto.getProfessorId())
                     .orElseThrow(() -> new ApiException("Professor não encontrado"));
@@ -57,6 +61,9 @@ public class AlunoService {
         entity.setTelefone(dto.getTelefone());
         entity.setEmail(dto.getEmail());
         entity.setEnderecoCompleto(dto.getEnderecoCompleto());
+        if (dto.getSenha() != null) {
+            entity.setSenha(passwordEncoder.encode(dto.getSenha()));
+        }
         entity.setDataMatricula(dto.getDataMatricula());
         entity.setStatus(dto.getStatus());
         if (dto.getProfessorId() != null) {

--- a/src/main/java/com/example/demo/service/ProfessorService.java
+++ b/src/main/java/com/example/demo/service/ProfessorService.java
@@ -8,19 +8,23 @@ import com.example.demo.repository.ProfessorRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Service
 public class ProfessorService {
     private final ProfessorRepository repository;
     private final ProfessorMapper mapper;
+    private final PasswordEncoder passwordEncoder;
 
-    public ProfessorService(ProfessorRepository repository, ProfessorMapper mapper) {
+    public ProfessorService(ProfessorRepository repository, ProfessorMapper mapper, PasswordEncoder passwordEncoder) {
         this.repository = repository;
         this.mapper = mapper;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public String create(ProfessorDTO dto) {
         Professor entity = mapper.toEntity(dto);
+        entity.setSenha(passwordEncoder.encode(dto.getSenha()));
         repository.save(entity);
         return "Professor criado com sucesso";
     }
@@ -43,6 +47,9 @@ public class ProfessorService {
         entity.setTelefone(dto.getTelefone());
         entity.setEmail(dto.getEmail());
         entity.setEnderecoCompleto(dto.getEnderecoCompleto());
+        if (dto.getSenha() != null) {
+            entity.setSenha(passwordEncoder.encode(dto.getSenha()));
+        }
         repository.save(entity);
         return "Professor atualizado";
     }


### PR DESCRIPTION
## Resumo
- Adiciona campo de senha ao usuário com armazenamento criptografado
- Inclui repositório de usuários e ajuste nos serviços para tratar senhas
- Configura autenticação para buscar usuários no banco de dados

## Testes
- `mvn -q -e test` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897e27b9fe4832781bb26288d47605d