### PR TITLE
Implementa fluxo de senhas via e-mail e ajustes de acesso

### DIFF
--- a/src/main/java/com/example/demo/dto/AlterarSenhaDTO.java
+++ b/src/main/java/com/example/demo/dto/AlterarSenhaDTO.java
@@ -1,0 +1,31 @@
+package com.example.demo.dto;
+
+public class AlterarSenhaDTO {
+    private String login;
+    private String senhaAtual;
+    private String novaSenha;
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getSenhaAtual() {
+        return senhaAtual;
+    }
+
+    public void setSenhaAtual(String senhaAtual) {
+        this.senhaAtual = senhaAtual;
+    }
+
+    public String getNovaSenha() {
+        return novaSenha;
+    }
+
+    public void setNovaSenha(String novaSenha) {
+        this.novaSenha = novaSenha;
+    }
+}

--- a/src/main/java/com/example/demo/dto/AuthResponse.java
+++ b/src/main/java/com/example/demo/dto/AuthResponse.java
@@ -1,0 +1,30 @@
+package com.example.demo.dto;
+
+public class AuthResponse {
+    private String token;
+    private boolean primeiroAcesso;
+
+    public AuthResponse() {
+    }
+
+    public AuthResponse(String token, boolean primeiroAcesso) {
+        this.token = token;
+        this.primeiroAcesso = primeiroAcesso;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public boolean isPrimeiroAcesso() {
+        return primeiroAcesso;
+    }
+
+    public void setPrimeiroAcesso(boolean primeiroAcesso) {
+        this.primeiroAcesso = primeiroAcesso;
+    }
+}

--- a/src/main/java/com/example/demo/dto/ReenviarSenhaDTO.java
+++ b/src/main/java/com/example/demo/dto/ReenviarSenhaDTO.java
@@ -1,0 +1,13 @@
+package com.example.demo.dto;
+
+public class ReenviarSenhaDTO {
+    private String login;
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+}

--- a/src/main/java/com/example/demo/dto/UsuarioDTO.java
+++ b/src/main/java/com/example/demo/dto/UsuarioDTO.java
@@ -1,7 +1,6 @@
 package com.example.demo.dto;
 
 import com.example.demo.domain.enums.Perfil;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -13,8 +12,6 @@ public class UsuarioDTO {
     private LocalDate dataNascimento;
     private String telefone;
     private String email;
-    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-    private String senha;
     private String enderecoCompleto;
     private Perfil perfil;
 
@@ -72,14 +69,6 @@ public class UsuarioDTO {
 
     public void setEmail(String email) {
         this.email = email;
-    }
-
-    public String getSenha() {
-        return senha;
-    }
-
-    public void setSenha(String senha) {
-        this.senha = senha;
     }
 
     public String getEnderecoCompleto() {

--- a/src/main/java/com/example/demo/service/AcademiaService.java
+++ b/src/main/java/com/example/demo/service/AcademiaService.java
@@ -2,8 +2,12 @@ package com.example.demo.service;
 
 import com.example.demo.dto.AcademiaDTO;
 import com.example.demo.entity.Academia;
+import com.example.demo.entity.Usuario;
 import com.example.demo.mapper.AcademiaMapper;
 import com.example.demo.repository.AcademiaRepository;
+import com.example.demo.domain.enums.Perfil;
+import com.example.demo.common.util.SenhaUtil;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -12,15 +16,25 @@ import org.springframework.stereotype.Service;
 public class AcademiaService {
     private final AcademiaRepository repository;
     private final AcademiaMapper mapper;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
 
-    public AcademiaService(AcademiaRepository repository, AcademiaMapper mapper) {
+    public AcademiaService(AcademiaRepository repository, AcademiaMapper mapper, PasswordEncoder passwordEncoder,
+                           EmailService emailService) {
         this.repository = repository;
         this.mapper = mapper;
+        this.passwordEncoder = passwordEncoder;
+        this.emailService = emailService;
     }
 
     public String create(AcademiaDTO dto) {
         Academia entity = mapper.toEntity(dto);
+        Usuario admin = entity.getAdmin();
+        String senha = SenhaUtil.gerarSenhaNumerica(6);
+        admin.setSenha(passwordEncoder.encode(senha));
+        admin.setPerfil(Perfil.ADMIN);
         repository.save(entity);
+        emailService.enviarSenha(admin.getEmail(), senha);
         return "Academia criada com sucesso";
     }
 

--- a/src/main/java/com/example/demo/service/EmailService.java
+++ b/src/main/java/com/example/demo/service/EmailService.java
@@ -1,0 +1,29 @@
+package com.example.demo.service;
+
+import com.example.demo.common.config.email.MailProperties;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+    private final JavaMailSender mailSender;
+    private final MailProperties mailProperties;
+
+    public EmailService(JavaMailSender mailSender, MailProperties mailProperties) {
+        this.mailSender = mailSender;
+        this.mailProperties = mailProperties;
+    }
+
+    public void enviarSenha(String destinatario, String senha) {
+        if (destinatario == null || destinatario.isBlank()) {
+            return;
+        }
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(mailProperties.getFrom());
+        message.setTo(destinatario);
+        message.setSubject("Senha de acesso");
+        message.setText("Sua senha temporária é: " + senha);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/example/demo/service/ProfessorService.java
+++ b/src/main/java/com/example/demo/service/ProfessorService.java
@@ -5,6 +5,8 @@ import com.example.demo.entity.Professor;
 import com.example.demo.exception.ApiException;
 import com.example.demo.mapper.ProfessorMapper;
 import com.example.demo.repository.ProfessorRepository;
+import com.example.demo.domain.enums.Perfil;
+import com.example.demo.common.util.SenhaUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,17 +17,23 @@ public class ProfessorService {
     private final ProfessorRepository repository;
     private final ProfessorMapper mapper;
     private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
 
-    public ProfessorService(ProfessorRepository repository, ProfessorMapper mapper, PasswordEncoder passwordEncoder) {
+    public ProfessorService(ProfessorRepository repository, ProfessorMapper mapper, PasswordEncoder passwordEncoder,
+                            EmailService emailService) {
         this.repository = repository;
         this.mapper = mapper;
         this.passwordEncoder = passwordEncoder;
+        this.emailService = emailService;
     }
 
     public String create(ProfessorDTO dto) {
         Professor entity = mapper.toEntity(dto);
-        entity.setSenha(passwordEncoder.encode(dto.getSenha()));
+        String senha = SenhaUtil.gerarSenhaNumerica(6);
+        entity.setSenha(passwordEncoder.encode(senha));
+        entity.setPerfil(Perfil.PROFESSOR);
         repository.save(entity);
+        emailService.enviarSenha(entity.getEmail(), senha);
         return "Professor criado com sucesso";
     }
 
@@ -47,9 +55,6 @@ public class ProfessorService {
         entity.setTelefone(dto.getTelefone());
         entity.setEmail(dto.getEmail());
         entity.setEnderecoCompleto(dto.getEnderecoCompleto());
-        if (dto.getSenha() != null) {
-            entity.setSenha(passwordEncoder.encode(dto.getSenha()));
-        }
         repository.save(entity);
         return "Professor atualizado";
     }


### PR DESCRIPTION
## Resumo
- Remove envio de senha nos cadastros
- Gera senhas numéricas aleatórias e envia por e-mail
- Adiciona endpoints para reenviar e alterar senha, indicando primeiro acesso

## Testes
- `mvn -q test` *(falha: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898162277d4832789bd65b8f0ed9603