### PR TITLE
Ajuste no ModelMapper para ignorar campos nulos

### DIFF
--- a/src/main/java/com/example/demo/config/ModelMapperConfig.java
+++ b/src/main/java/com/example/demo/config/ModelMapperConfig.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Configuration;
 public class ModelMapperConfig {
     @Bean
     public ModelMapper modelMapper() {
-        return new ModelMapper();
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setSkipNullEnabled(true);
+        return mapper;
     }
 }


### PR DESCRIPTION
## Resumo
- Configura o ModelMapper para ignorar propriedades nulas, evitando que o UUID padrão seja sobrescrito por `null` durante a criação de usuários

## Testes
- `mvn -q test` *(falhou: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899042a994883278c75a050d6901980