### PR TITLE
Gerar UUID automaticamente ao criar usuario

### DIFF
--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "Alunos")
 @Slf4j
@@ -42,47 +43,47 @@ public class AlunoController {
         return ResponseEntity.ok(new ApiResponse<>(true, "Lista de alunos", page, null));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<AlunoDTO>> buscar(@PathVariable Long id) {
-        AlunoDTO dto = service.findById(id);
+    @GetMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<AlunoDTO>> buscar(@PathVariable UUID uuid) {
+        AlunoDTO dto = service.findByUuid(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Aluno encontrado", dto, null));
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<String>> atualizar(@PathVariable Long id, @Validated @RequestBody AlunoDTO dto) {
-        String msg = service.update(id, dto);
+    @PutMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<String>> atualizar(@PathVariable UUID uuid, @Validated @RequestBody AlunoDTO dto) {
+        String msg = service.update(uuid, dto);
         return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> remover(@PathVariable Long id) {
-        service.delete(id);
+    @DeleteMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<Void>> remover(@PathVariable UUID uuid) {
+        service.delete(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Aluno removido", null, null));
     }
 
-    @PostMapping("/{id}/medidas")
-    public ResponseEntity<ApiResponse<String>> adicionarMedida(@PathVariable Long id,
+    @PostMapping("/{uuid}/medidas")
+    public ResponseEntity<ApiResponse<String>> adicionarMedida(@PathVariable UUID uuid,
                                                                @Validated @RequestBody AlunoMedidaDTO dto) {
-        String msg = medidaService.adicionarMedida(id, dto);
+        String msg = medidaService.adicionarMedida(uuid, dto);
         return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
-    @GetMapping("/{id}/medidas")
-    public ResponseEntity<ApiResponse<List<AlunoMedidaDTO>>> listarMedidas(@PathVariable Long id) {
-        List<AlunoMedidaDTO> lista = medidaService.listarMedidas(id);
+    @GetMapping("/{uuid}/medidas")
+    public ResponseEntity<ApiResponse<List<AlunoMedidaDTO>>> listarMedidas(@PathVariable UUID uuid) {
+        List<AlunoMedidaDTO> lista = medidaService.listarMedidas(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Lista de medidas", lista, null));
     }
 
-    @PostMapping("/{id}/observacoes")
-    public ResponseEntity<ApiResponse<String>> adicionarObservacao(@PathVariable Long id,
+    @PostMapping("/{uuid}/observacoes")
+    public ResponseEntity<ApiResponse<String>> adicionarObservacao(@PathVariable UUID uuid,
                                                                    @Validated @RequestBody AlunoObservacaoDTO dto) {
-        String msg = observacaoService.adicionarObservacao(id, dto);
+        String msg = observacaoService.adicionarObservacao(uuid, dto);
         return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
-    @GetMapping("/{id}/observacoes")
-    public ResponseEntity<ApiResponse<List<AlunoObservacaoDTO>>> listarObservacoes(@PathVariable Long id) {
-        List<AlunoObservacaoDTO> lista = observacaoService.listarObservacoes(id);
+    @GetMapping("/{uuid}/observacoes")
+    public ResponseEntity<ApiResponse<List<AlunoObservacaoDTO>>> listarObservacoes(@PathVariable UUID uuid) {
+        List<AlunoObservacaoDTO> lista = observacaoService.listarObservacoes(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Lista de observações", lista, null));
     }
 }

--- a/src/main/java/com/example/demo/controller/ProfessorController.java
+++ b/src/main/java/com/example/demo/controller/ProfessorController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 
 @Tag(name = "Professores")
 @RestController
@@ -32,21 +33,21 @@ public class ProfessorController {
         return ResponseEntity.ok(new ApiResponse<>(true, "Lista de professores", page, null));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<ProfessorDTO>> buscar(@PathVariable Long id) {
-        ProfessorDTO dto = service.findById(id);
+    @GetMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<ProfessorDTO>> buscar(@PathVariable UUID uuid) {
+        ProfessorDTO dto = service.findByUuid(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Professor encontrado", dto, null));
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<String>> atualizar(@PathVariable Long id, @Validated @RequestBody ProfessorDTO dto) {
-        String msg = service.update(id, dto);
+    @PutMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<String>> atualizar(@PathVariable UUID uuid, @Validated @RequestBody ProfessorDTO dto) {
+        String msg = service.update(uuid, dto);
         return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> remover(@PathVariable Long id) {
-        service.delete(id);
+    @DeleteMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<Void>> remover(@PathVariable UUID uuid) {
+        service.delete(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Professor removido", null, null));
     }
 }

--- a/src/main/java/com/example/demo/dto/AlunoDTO.java
+++ b/src/main/java/com/example/demo/dto/AlunoDTO.java
@@ -3,11 +3,12 @@ package com.example.demo.dto;
 import com.example.demo.entity.StatusAluno;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 public class AlunoDTO extends UsuarioDTO {
     private LocalDate dataMatricula;
     private StatusAluno status;
-    private Long professorId;
+    private UUID professorUuid;
 
     public LocalDate getDataMatricula() {
         return dataMatricula;
@@ -25,11 +26,11 @@ public class AlunoDTO extends UsuarioDTO {
         this.status = status;
     }
 
-    public Long getProfessorId() {
-        return professorId;
+    public UUID getProfessorUuid() {
+        return professorUuid;
     }
 
-    public void setProfessorId(Long professorId) {
-        this.professorId = professorId;
+    public void setProfessorUuid(UUID professorUuid) {
+        this.professorUuid = professorUuid;
     }
 }

--- a/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
@@ -1,11 +1,12 @@
 package com.example.demo.dto;
 
 import java.util.List;
+import java.util.UUID;
 
 public class FichaTreinoDTO {
     private Long id;
-    private Long alunoId;
-    private Long professorId;
+    private UUID alunoUuid;
+    private UUID professorUuid;
     private List<Long> exerciciosIds;
 
     public Long getId() {
@@ -16,20 +17,20 @@ public class FichaTreinoDTO {
         this.id = id;
     }
 
-    public Long getAlunoId() {
-        return alunoId;
+    public UUID getAlunoUuid() {
+        return alunoUuid;
     }
 
-    public void setAlunoId(Long alunoId) {
-        this.alunoId = alunoId;
+    public void setAlunoUuid(UUID alunoUuid) {
+        this.alunoUuid = alunoUuid;
     }
 
-    public Long getProfessorId() {
-        return professorId;
+    public UUID getProfessorUuid() {
+        return professorUuid;
     }
 
-    public void setProfessorId(Long professorId) {
-        this.professorId = professorId;
+    public void setProfessorUuid(UUID professorUuid) {
+        this.professorUuid = professorUuid;
     }
 
     public List<Long> getExerciciosIds() {

--- a/src/main/java/com/example/demo/dto/UsuarioDTO.java
+++ b/src/main/java/com/example/demo/dto/UsuarioDTO.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public class UsuarioDTO {
-    private Long id;
     private UUID uuid;
     private String nome;
     private String cpf;
@@ -19,14 +18,6 @@ public class UsuarioDTO {
     private String uf;
     private String cidade;
     private Perfil perfil;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public UUID getUuid() {
         return uuid;

--- a/src/main/java/com/example/demo/entity/Academia.java
+++ b/src/main/java/com/example/demo/entity/Academia.java
@@ -21,6 +21,6 @@ public class Academia {
     private String telefone;
 
     @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "admin_id", nullable = false)
+    @JoinColumn(name = "admin_uuid", referencedColumnName = "uuid", nullable = false)
     private Usuario admin;
 }

--- a/src/main/java/com/example/demo/entity/Usuario.java
+++ b/src/main/java/com/example/demo/entity/Usuario.java
@@ -16,11 +16,8 @@ import java.util.UUID;
 @DiscriminatorColumn(name = "tipo")
 public class Usuario {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     @Column(nullable = false, unique = true, updatable = false)
-    private UUID uuid = UUID.randomUUID();
+    private UUID uuid;
 
     @Column(nullable = false)
     private String nome;
@@ -56,4 +53,11 @@ public class Usuario {
 
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    @PrePersist
+    private void gerarUuid() {
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+    }
 }

--- a/src/main/java/com/example/demo/mapper/AlunoMapper.java
+++ b/src/main/java/com/example/demo/mapper/AlunoMapper.java
@@ -16,7 +16,7 @@ public class AlunoMapper {
     public AlunoDTO toDto(Aluno aluno) {
         AlunoDTO dto = mapper.map(aluno, AlunoDTO.class);
         if (aluno.getProfessor() != null) {
-            dto.setProfessorId(aluno.getProfessor().getId());
+            dto.setProfessorUuid(aluno.getProfessor().getUuid());
         }
         return dto;
     }

--- a/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
+++ b/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
@@ -19,9 +19,9 @@ public class FichaTreinoMapper {
     public FichaTreinoDTO toDto(FichaTreino ficha) {
         FichaTreinoDTO dto = new FichaTreinoDTO();
         dto.setId(ficha.getId());
-        dto.setAlunoId(ficha.getAluno().getId());
+        dto.setAlunoUuid(ficha.getAluno().getUuid());
         if (ficha.getProfessor() != null) {
-            dto.setProfessorId(ficha.getProfessor().getId());
+            dto.setProfessorUuid(ficha.getProfessor().getUuid());
         }
         dto.setExerciciosIds(ficha.getExercicios().stream().map(Exercicio::getId).collect(Collectors.toList()));
         return dto;

--- a/src/main/java/com/example/demo/repository/AlunoMedidaRepository.java
+++ b/src/main/java/com/example/demo/repository/AlunoMedidaRepository.java
@@ -4,7 +4,8 @@ import com.example.demo.entity.AlunoMedida;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface AlunoMedidaRepository extends JpaRepository<AlunoMedida, Long> {
-    List<AlunoMedida> findByAlunoId(Long alunoId);
+    List<AlunoMedida> findByAlunoUuid(UUID alunoUuid);
 }

--- a/src/main/java/com/example/demo/repository/AlunoObservacaoRepository.java
+++ b/src/main/java/com/example/demo/repository/AlunoObservacaoRepository.java
@@ -4,7 +4,8 @@ import com.example.demo.entity.AlunoObservacao;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface AlunoObservacaoRepository extends JpaRepository<AlunoObservacao, Long> {
-    List<AlunoObservacao> findByAlunoId(Long alunoId);
+    List<AlunoObservacao> findByAlunoUuid(UUID alunoUuid);
 }

--- a/src/main/java/com/example/demo/repository/AlunoRepository.java
+++ b/src/main/java/com/example/demo/repository/AlunoRepository.java
@@ -1,6 +1,9 @@
 package com.example.demo.repository;
 
 import com.example.demo.entity.Aluno;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlunoRepository extends BaseRepository<Aluno, Long> {
+import java.util.UUID;
+
+public interface AlunoRepository extends JpaRepository<Aluno, UUID> {
 }

--- a/src/main/java/com/example/demo/repository/ProfessorRepository.java
+++ b/src/main/java/com/example/demo/repository/ProfessorRepository.java
@@ -3,5 +3,7 @@ package com.example.demo.repository;
 import com.example.demo.entity.Professor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProfessorRepository extends JpaRepository<Professor, Long> {
+import java.util.UUID;
+
+public interface ProfessorRepository extends JpaRepository<Professor, UUID> {
 }

--- a/src/main/java/com/example/demo/repository/UsuarioRepository.java
+++ b/src/main/java/com/example/demo/repository/UsuarioRepository.java
@@ -7,12 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
     Optional<Usuario> findByEmail(String email);
 
     Optional<Usuario> findByCpfOrEmailOrTelefone(String cpf, String email, String telefone);
 
-        Optional<Usuario> findByUuid(UUID uuid);
+    Optional<Usuario> findByUuid(UUID uuid);
 //    @Query(value = "select * from public.usuario where uuid = :uuid", nativeQuery = true)
 //    Optional<Usuario> findNativeByUuid(@Param("uuid") UUID uuid);
 

--- a/src/main/java/com/example/demo/service/AlunoMedidaService.java
+++ b/src/main/java/com/example/demo/service/AlunoMedidaService.java
@@ -10,6 +10,7 @@ import com.example.demo.repository.AlunoRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,8 +28,8 @@ public class AlunoMedidaService {
         this.mapper = mapper;
     }
 
-    public String adicionarMedida(Long alunoId, AlunoMedidaDTO dto) {
-        Aluno aluno = alunoRepository.findById(alunoId)
+    public String adicionarMedida(UUID alunoUuid, AlunoMedidaDTO dto) {
+        Aluno aluno = alunoRepository.findById(alunoUuid)
                 .orElseThrow(() -> new ApiException("Aluno não encontrado"));
         AlunoMedida medida = mapper.toEntity(dto);
         medida.setAluno(aluno);
@@ -36,8 +37,8 @@ public class AlunoMedidaService {
         return "Medida registrada com sucesso";
     }
 
-    public List<AlunoMedidaDTO> listarMedidas(Long alunoId) {
-        return repository.findByAlunoId(alunoId)
+    public List<AlunoMedidaDTO> listarMedidas(UUID alunoUuid) {
+        return repository.findByAlunoUuid(alunoUuid)
                 .stream()
                 .map(mapper::toDto)
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/demo/service/AlunoObservacaoService.java
+++ b/src/main/java/com/example/demo/service/AlunoObservacaoService.java
@@ -10,6 +10,7 @@ import com.example.demo.repository.AlunoRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,8 +28,8 @@ public class AlunoObservacaoService {
         this.mapper = mapper;
     }
 
-    public String adicionarObservacao(Long alunoId, AlunoObservacaoDTO dto) {
-        Aluno aluno = alunoRepository.findById(alunoId)
+    public String adicionarObservacao(UUID alunoUuid, AlunoObservacaoDTO dto) {
+        Aluno aluno = alunoRepository.findById(alunoUuid)
                 .orElseThrow(() -> new ApiException("Aluno não encontrado"));
         AlunoObservacao obs = mapper.toEntity(dto);
         obs.setAluno(aluno);
@@ -36,8 +37,8 @@ public class AlunoObservacaoService {
         return "Observação registrada com sucesso";
     }
 
-    public List<AlunoObservacaoDTO> listarObservacoes(Long alunoId) {
-        return repository.findByAlunoId(alunoId)
+    public List<AlunoObservacaoDTO> listarObservacoes(UUID alunoUuid) {
+        return repository.findByAlunoUuid(alunoUuid)
                 .stream()
                 .map(mapper::toDto)
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/demo/service/AlunoService.java
+++ b/src/main/java/com/example/demo/service/AlunoService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class AlunoService {
@@ -43,8 +44,8 @@ public class AlunoService {
         String senha = SenhaUtil.gerarSenhaNumerica(6);
         entity.setSenha(passwordEncoder.encode(senha));
         entity.setPerfil(Perfil.ALUNO);
-        if (dto.getProfessorId() != null) {
-            Professor professor = professorRepository.findById(dto.getProfessorId())
+        if (dto.getProfessorUuid() != null) {
+            Professor professor = professorRepository.findById(dto.getProfessorUuid())
                     .orElseThrow(() -> new ApiException("Professor não encontrado"));
             entity.setProfessor(professor);
         }
@@ -57,13 +58,13 @@ public class AlunoService {
         return repository.findAll(pageable).map(mapper::toDto);
     }
 
-    public AlunoDTO findById(Long id) {
-        Aluno entity = repository.findById(id).orElseThrow(() -> new ApiException("Aluno não encontrado"));
+    public AlunoDTO findByUuid(UUID uuid) {
+        Aluno entity = repository.findById(uuid).orElseThrow(() -> new ApiException("Aluno não encontrado"));
         return mapper.toDto(entity);
     }
 
-    public String update(Long id, AlunoDTO dto) {
-        Optional<Aluno> opt = repository.findById(id);
+    public String update(UUID uuid, AlunoDTO dto) {
+        Optional<Aluno> opt = repository.findById(uuid);
         if (opt.isEmpty()) {
             throw new ApiException("Aluno não encontrado");
         }
@@ -81,8 +82,8 @@ public class AlunoService {
         entity.setCidade(dto.getCidade());
         entity.setDataMatricula(dto.getDataMatricula());
         entity.setStatus(dto.getStatus());
-        if (dto.getProfessorId() != null) {
-            Professor professor = professorRepository.findById(dto.getProfessorId())
+        if (dto.getProfessorUuid() != null) {
+            Professor professor = professorRepository.findById(dto.getProfessorUuid())
                     .orElseThrow(() -> new ApiException("Professor não encontrado"));
             entity.setProfessor(professor);
         } else {
@@ -92,7 +93,7 @@ public class AlunoService {
         return "Aluno atualizado";
     }
 
-    public void delete(Long id) {
-        repository.deleteById(id);
+    public void delete(UUID uuid) {
+        repository.deleteById(uuid);
     }
 }

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class FichaTreinoService {
@@ -37,11 +38,11 @@ public class FichaTreinoService {
 
     public String create(FichaTreinoDTO dto) {
         FichaTreino ficha = new FichaTreino();
-        Aluno aluno = alunoRepository.findById(dto.getAlunoId())
+        Aluno aluno = alunoRepository.findById(dto.getAlunoUuid())
                 .orElseThrow(() -> new ApiException("Aluno não encontrado"));
         ficha.setAluno(aluno);
-        if (dto.getProfessorId() != null) {
-            Professor professor = professorRepository.findById(dto.getProfessorId())
+        if (dto.getProfessorUuid() != null) {
+            Professor professor = professorRepository.findById(dto.getProfessorUuid())
                     .orElseThrow(() -> new ApiException("Professor não encontrado"));
             ficha.setProfessor(professor);
         }

--- a/src/main/java/com/example/demo/service/ProfessorService.java
+++ b/src/main/java/com/example/demo/service/ProfessorService.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.UUID;
+
 @Service
 public class ProfessorService {
     private final ProfessorRepository repository;
@@ -46,13 +48,13 @@ public class ProfessorService {
         return repository.findAll(pageable).map(mapper::toDto);
     }
 
-    public ProfessorDTO findById(Long id) {
-        Professor entity = repository.findById(id).orElseThrow(() -> new ApiException("Professor não encontrado"));
+    public ProfessorDTO findByUuid(UUID uuid) {
+        Professor entity = repository.findById(uuid).orElseThrow(() -> new ApiException("Professor não encontrado"));
         return mapper.toDto(entity);
     }
 
-    public String update(Long id, ProfessorDTO dto) {
-        Professor entity = repository.findById(id)
+    public String update(UUID uuid, ProfessorDTO dto) {
+        Professor entity = repository.findById(uuid)
                 .orElseThrow(() -> new ApiException("Professor não encontrado"));
         entity.setNome(dto.getNome());
         entity.setCpf(dto.getCpf());
@@ -69,7 +71,7 @@ public class ProfessorService {
         return "Professor atualizado";
     }
 
-    public void delete(Long id) {
-        repository.deleteById(id);
+    public void delete(UUID uuid) {
+        repository.deleteById(uuid);
     }
 }


### PR DESCRIPTION
## Summary
- Substitui campos de ID numéricos por UUID como chave primária de usuários
- Atualiza serviços, repositórios, mapeadores e controladores para usar UUID
- Ajusta mapeamento de Academia para referenciar administrador por UUID

## Testing
- `mvn -q test` *(falhou: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899d28eeee88327874719eebc67e529