### PR TITLE
Adicionar roles nas controllers

### DIFF
--- a/src/main/java/com/example/demo/common/config/security/UserAuthenticationConfig.java
+++ b/src/main/java/com/example/demo/common/config/security/UserAuthenticationConfig.java
@@ -21,7 +21,7 @@ public class UserAuthenticationConfig {
         return username -> repository.findByEmail(username)
                 .map(usuario -> User.withUsername(usuario.getEmail())
                         .password(usuario.getSenha())
-                        .roles("USER")
+                        .roles(usuario.getPerfil().name())
                         .build())
                 .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
     }

--- a/src/main/java/com/example/demo/common/security/UsuarioLogado.java
+++ b/src/main/java/com/example/demo/common/security/UsuarioLogado.java
@@ -3,9 +3,10 @@ package com.example.demo.common.security;
 import com.example.demo.domain.enums.Perfil;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -34,7 +35,7 @@ public class UsuarioLogado implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.emptyList();
+        return List.of(new SimpleGrantedAuthority("ROLE_" + perfil.name()));
     }
 
     @Override

--- a/src/main/java/com/example/demo/controller/AcademiaController.java
+++ b/src/main/java/com/example/demo/controller/AcademiaController.java
@@ -6,6 +6,7 @@ import com.example.demo.service.AcademiaService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Academias")
 @RestController
 @RequestMapping("/academias")
+@PreAuthorize("hasAnyRole('MASTER','ADMIN')")
 public class AcademiaController {
     private final AcademiaService service;
 

--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @Slf4j
 @RestController
 @RequestMapping("/alunos")
+@PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
 public class AlunoController {
     private final AlunoService service;
     private final AlunoMedidaService medidaService;

--- a/src/main/java/com/example/demo/controller/ExercicioController.java
+++ b/src/main/java/com/example/demo/controller/ExercicioController.java
@@ -6,6 +6,7 @@ import com.example.demo.service.ExercicioService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Exercícios")
 @RestController
 @RequestMapping("/exercicios")
+@PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
 public class ExercicioController {
     private final ExercicioService service;
 

--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -6,6 +6,7 @@ import com.example.demo.service.FichaTreinoService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,6 +17,7 @@ import java.util.UUID;
 @Tag(name = "Fichas de Treino")
 @RestController
 @RequestMapping("/fichas")
+@PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
 public class FichaTreinoController {
     private final FichaTreinoService service;
 

--- a/src/main/java/com/example/demo/controller/ProfessorController.java
+++ b/src/main/java/com/example/demo/controller/ProfessorController.java
@@ -6,6 +6,7 @@ import com.example.demo.service.ProfessorService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,6 +15,7 @@ import java.util.UUID;
 @Tag(name = "Professores")
 @RestController
 @RequestMapping("/professores")
+@PreAuthorize("hasAnyRole('MASTER','ADMIN')")
 public class ProfessorController {
     private final ProfessorService service;
 

--- a/src/main/java/com/example/demo/controller/UsuarioLogadoController.java
+++ b/src/main/java/com/example/demo/controller/UsuarioLogadoController.java
@@ -4,6 +4,7 @@ import com.example.demo.dto.ApiResponse;
 import com.example.demo.dto.UsuarioDTO;
 import com.example.demo.service.UsuarioService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Usuário Logado")
 @RestController
 @RequestMapping("/api/usuario")
+@PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR','ALUNO')")
 public class UsuarioLogadoController {
 
     private final UsuarioService service;


### PR DESCRIPTION
## Resumo
- Definido papel do usuário ao carregar detalhes para autenticação
- Incluído retorno de autoridade no objeto do usuário logado
- Protegidos endpoints com `@PreAuthorize` exigindo perfis específicos

## Testes
- `mvn -q test` *(falhou: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a2ab6cfdc83278f935fec5f788695