### PR TITLE
Usar academia do usuário logado nas buscas de exercícios

### DIFF
--- a/src/main/java/com/example/demo/entity/Usuario.java
+++ b/src/main/java/com/example/demo/entity/Usuario.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import com.example.demo.entity.Academia;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -44,6 +45,10 @@ public class Usuario {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Perfil perfil;
+
+    @ManyToOne
+    @JoinColumn(name = "academia_uuid")
+    private Academia academia;
 
     private LocalDateTime ultimoAcesso;
 

--- a/src/main/java/com/example/demo/repository/ExercicioRepository.java
+++ b/src/main/java/com/example/demo/repository/ExercicioRepository.java
@@ -4,14 +4,11 @@ import com.example.demo.entity.Exercicio;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 
 public interface ExercicioRepository extends JpaRepository<Exercicio, UUID> {
     Page<Exercicio> findByAcademiaIsNull(Pageable pageable);
 
-    @Query("SELECT e FROM Exercicio e WHERE e.academia IS NULL OR e.academia.uuid = :academiaUuid")
-    Page<Exercicio> findByAcademiaIsNullOrAcademiaUuid(@Param("academiaUuid") UUID academiaUuid, Pageable pageable);
+    Page<Exercicio> findByAcademiaUuid(UUID academiaUuid, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/ExercicioService.java
+++ b/src/main/java/com/example/demo/service/ExercicioService.java
@@ -3,11 +3,13 @@ package com.example.demo.service;
 import com.example.demo.dto.ExercicioDTO;
 import com.example.demo.entity.Exercicio;
 import com.example.demo.mapper.ExercicioMapper;
-import com.example.demo.repository.AcademiaRepository;
 import com.example.demo.repository.ExercicioRepository;
+import com.example.demo.repository.UsuarioRepository;
 import com.example.demo.common.security.SecurityUtils;
 import com.example.demo.common.security.UsuarioLogado;
 import com.example.demo.entity.Academia;
+import com.example.demo.entity.Usuario;
+import com.example.demo.domain.enums.Perfil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,22 +18,30 @@ import org.springframework.stereotype.Service;
 public class ExercicioService {
     private final ExercicioRepository repository;
     private final ExercicioMapper mapper;
-    private final AcademiaRepository academiaRepository;
+    private final UsuarioRepository usuarioRepository;
 
     public ExercicioService(ExercicioRepository repository, ExercicioMapper mapper,
-                            AcademiaRepository academiaRepository) {
+                            UsuarioRepository usuarioRepository) {
         this.repository = repository;
         this.mapper = mapper;
-        this.academiaRepository = academiaRepository;
+        this.usuarioRepository = usuarioRepository;
     }
 
     public String create(ExercicioDTO dto) {
         Exercicio entity = mapper.toEntity(dto);
         UsuarioLogado usuario = SecurityUtils.getUsuarioLogado();
-        if (usuario != null) {
-            academiaRepository.findByAdminUuid(usuario.getUuid())
-                    .ifPresent(entity::setAcademia);
+        boolean isMaster = usuario != null && usuario.possuiPerfil(Perfil.MASTER);
+
+        if (usuario != null && !isMaster) {
+            Usuario usuarioEntity = usuarioRepository.findByUuid(usuario.getUuid())
+                    .orElseThrow(() -> new IllegalArgumentException("Usuário precisa ter uma academia associada"));
+            Academia academia = usuarioEntity.getAcademia();
+            if (academia == null) {
+                throw new IllegalArgumentException("Usuário precisa ter uma academia associada");
+            }
+            entity.setAcademia(academia);
         }
+
         repository.save(entity);
         return "Exercício criado com sucesso";
     }
@@ -39,16 +49,23 @@ public class ExercicioService {
     public Page<ExercicioDTO> findAll(Pageable pageable) {
         UsuarioLogado usuario = SecurityUtils.getUsuarioLogado();
         Page<Exercicio> page;
-        if (usuario != null) {
-            Academia academia = academiaRepository.findByAdminUuid(usuario.getUuid()).orElse(null);
-            if (academia != null) {
-                page = repository.findByAcademiaIsNullOrAcademiaUuid(academia.getUuid(), pageable);
-            } else {
-                page = repository.findByAcademiaIsNull(pageable);
-            }
-        } else {
+
+        boolean isMaster = usuario != null && usuario.possuiPerfil(Perfil.MASTER);
+
+        if (isMaster) {
             page = repository.findByAcademiaIsNull(pageable);
+        } else {
+            Usuario usuarioEntity = usuarioRepository.findByUuid(usuario.getUuid())
+                    .orElseThrow(() -> new IllegalArgumentException("Usuário precisa ter uma academia associada"));
+            Academia academia = usuarioEntity.getAcademia();
+
+            if (academia == null) {
+                throw new IllegalArgumentException("Usuário precisa ter uma academia associada");
+            }
+
+            page = repository.findByAcademiaUuid(academia.getUuid(), pageable);
         }
+
         return page.map(mapper::toDto);
     }
 }


### PR DESCRIPTION
## Resumo
- Remover parâmetro `academiaUuid` do endpoint e serviço de exercícios
- Limitar buscas de exercícios à academia do usuário logado para perfis não MASTER
- Limpar repositório de exercícios de método não utilizado

## Testes
- `mvn -q test` *(falhou: Non-resolvable parent POM por falta de acesso à rede)*

------
https://chatgpt.com/codex/tasks/task_e_689a2d0daa90832799641d6a7d18661e