### PR TITLE
Associar academia do usuário logado nas operações de criação e atualização

### DIFF
--- a/src/main/java/com/example/demo/repository/ProfessorRepository.java
+++ b/src/main/java/com/example/demo/repository/ProfessorRepository.java
@@ -1,9 +1,12 @@
 package com.example.demo.repository;
 
 import com.example.demo.entity.Professor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface ProfessorRepository extends JpaRepository<Professor, UUID> {
+    Page<Professor> findByAcademiaUuid(UUID uuid, Pageable pageable);
 }


### PR DESCRIPTION
## Resumo
- garantir que alunos e professores criados ou atualizados sejam vinculados à academia do usuário logado quando o perfil não é MASTER
- limitar a listagem de alunos e professores à academia do usuário logado para perfis não MASTER
- validar a academia em fichas de treino criadas por usuários não MASTER

## Testes
- `./mvnw -q test` *(falhou ao baixar dependências Maven)*

------
https://chatgpt.com/codex/tasks/task_e_689a376aacf883278de0d78a6da61817