### PR TITLE
Adicionar solicitação de vínculo professor-aluno

### DIFF
--- a/src/main/java/com/example/demo/controller/SolicitacaoController.java
+++ b/src/main/java/com/example/demo/controller/SolicitacaoController.java
@@ -1,0 +1,46 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.ApiResponse;
+import com.example.demo.dto.SolicitacaoDTO;
+import com.example.demo.service.SolicitacaoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Solicitações")
+@RestController
+@RequestMapping("/solicitacoes")
+public class SolicitacaoController {
+
+    private final SolicitacaoService service;
+
+    public SolicitacaoController(SolicitacaoService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/alunos/{alunoUuid}")
+    @PreAuthorize("hasRole('PROFESSOR')")
+    public ResponseEntity<ApiResponse<String>> solicitar(@PathVariable UUID alunoUuid) {
+        String msg = service.solicitar(alunoUuid);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
+    }
+
+    @PostMapping("/{uuid}/responder")
+    @PreAuthorize("hasRole('ALUNO')")
+    public ResponseEntity<ApiResponse<String>> responder(@PathVariable UUID uuid,
+                                                         @RequestParam boolean aceita) {
+        String msg = service.responder(uuid, aceita);
+        return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
+    }
+
+    @GetMapping("/alunos/{alunoUuid}")
+    @PreAuthorize("hasRole('ALUNO')")
+    public ResponseEntity<ApiResponse<List<SolicitacaoDTO>>> listarPendentes(@PathVariable UUID alunoUuid) {
+        List<SolicitacaoDTO> lista = service.listarPendentes(alunoUuid);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Solicitações pendentes", lista, null));
+    }
+}

--- a/src/main/java/com/example/demo/domain/enums/StatusSolicitacao.java
+++ b/src/main/java/com/example/demo/domain/enums/StatusSolicitacao.java
@@ -1,0 +1,5 @@
+package com.example.demo.domain.enums;
+
+public enum StatusSolicitacao {
+    PENDENTE, ACEITA, RECUSADA
+}

--- a/src/main/java/com/example/demo/dto/SolicitacaoDTO.java
+++ b/src/main/java/com/example/demo/dto/SolicitacaoDTO.java
@@ -1,0 +1,14 @@
+package com.example.demo.dto;
+
+import com.example.demo.domain.enums.StatusSolicitacao;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class SolicitacaoDTO {
+    private UUID uuid;
+    private UUID professorUuid;
+    private UUID alunoUuid;
+    private StatusSolicitacao status;
+}

--- a/src/main/java/com/example/demo/entity/Solicitacao.java
+++ b/src/main/java/com/example/demo/entity/Solicitacao.java
@@ -1,0 +1,35 @@
+package com.example.demo.entity;
+
+import com.example.demo.domain.enums.StatusSolicitacao;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Entity
+public class Solicitacao {
+
+    @Id
+    @Column(nullable = false, updatable = false, unique = true)
+    private UUID uuid;
+
+    @ManyToOne
+    @JoinColumn(name = "professor_id", nullable = false)
+    private Professor professor;
+
+    @ManyToOne
+    @JoinColumn(name = "aluno_id", nullable = false)
+    private Aluno aluno;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatusSolicitacao status = StatusSolicitacao.PENDENTE;
+
+    @PrePersist
+    private void gerarUuid() {
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/mapper/SolicitacaoMapper.java
+++ b/src/main/java/com/example/demo/mapper/SolicitacaoMapper.java
@@ -1,0 +1,22 @@
+package com.example.demo.mapper;
+
+import com.example.demo.dto.SolicitacaoDTO;
+import com.example.demo.entity.Solicitacao;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SolicitacaoMapper {
+    private final ModelMapper mapper;
+
+    public SolicitacaoMapper(ModelMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public SolicitacaoDTO toDto(Solicitacao solicitacao) {
+        SolicitacaoDTO dto = mapper.map(solicitacao, SolicitacaoDTO.class);
+        dto.setProfessorUuid(solicitacao.getProfessor().getUuid());
+        dto.setAlunoUuid(solicitacao.getAluno().getUuid());
+        return dto;
+    }
+}

--- a/src/main/java/com/example/demo/repository/SolicitacaoRepository.java
+++ b/src/main/java/com/example/demo/repository/SolicitacaoRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Solicitacao;
+import com.example.demo.domain.enums.StatusSolicitacao;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface SolicitacaoRepository extends JpaRepository<Solicitacao, UUID> {
+    List<Solicitacao> findByAlunoUuidAndStatus(UUID alunoUuid, StatusSolicitacao status);
+}

--- a/src/main/java/com/example/demo/service/SolicitacaoService.java
+++ b/src/main/java/com/example/demo/service/SolicitacaoService.java
@@ -1,0 +1,83 @@
+package com.example.demo.service;
+
+import com.example.demo.common.security.SecurityUtils;
+import com.example.demo.common.security.UsuarioLogado;
+import com.example.demo.domain.enums.StatusSolicitacao;
+import com.example.demo.dto.SolicitacaoDTO;
+import com.example.demo.entity.Aluno;
+import com.example.demo.entity.Professor;
+import com.example.demo.entity.Solicitacao;
+import com.example.demo.exception.ApiException;
+import com.example.demo.mapper.SolicitacaoMapper;
+import com.example.demo.repository.AlunoRepository;
+import com.example.demo.repository.ProfessorRepository;
+import com.example.demo.repository.SolicitacaoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class SolicitacaoService {
+
+    private final SolicitacaoRepository repository;
+    private final ProfessorRepository professorRepository;
+    private final AlunoRepository alunoRepository;
+    private final SolicitacaoMapper mapper;
+
+    public SolicitacaoService(SolicitacaoRepository repository,
+                              ProfessorRepository professorRepository,
+                              AlunoRepository alunoRepository,
+                              SolicitacaoMapper mapper) {
+        this.repository = repository;
+        this.professorRepository = professorRepository;
+        this.alunoRepository = alunoRepository;
+        this.mapper = mapper;
+    }
+
+    public String solicitar(UUID alunoUuid) {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogado();
+        if (usuario == null) {
+            throw new ApiException("Usuário não autenticado");
+        }
+        Professor professor = professorRepository.findById(usuario.getUuid())
+                .orElseThrow(() -> new ApiException("Professor não encontrado"));
+        Aluno aluno = alunoRepository.findById(alunoUuid)
+                .orElseThrow(() -> new ApiException("Aluno não encontrado"));
+        Solicitacao solicitacao = new Solicitacao();
+        solicitacao.setProfessor(professor);
+        solicitacao.setAluno(aluno);
+        repository.save(solicitacao);
+        return "Solicitação enviada";
+    }
+
+    public String responder(UUID solicitacaoUuid, boolean aceita) {
+        Solicitacao solicitacao = repository.findById(solicitacaoUuid)
+                .orElseThrow(() -> new ApiException("Solicitação não encontrada"));
+
+        if (solicitacao.getStatus() != StatusSolicitacao.PENDENTE) {
+            throw new ApiException("Solicitação já respondida");
+        }
+
+        if (aceita) {
+            solicitacao.setStatus(StatusSolicitacao.ACEITA);
+            repository.save(solicitacao);
+            Aluno aluno = solicitacao.getAluno();
+            aluno.setProfessor(solicitacao.getProfessor());
+            alunoRepository.save(aluno);
+            return "Solicitação aceita";
+        } else {
+            solicitacao.setStatus(StatusSolicitacao.RECUSADA);
+            repository.save(solicitacao);
+            return "Solicitação recusada";
+        }
+    }
+
+    public List<SolicitacaoDTO> listarPendentes(UUID alunoUuid) {
+        return repository.findByAlunoUuidAndStatus(alunoUuid, StatusSolicitacao.PENDENTE)
+                .stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Resumo
- Criar entidade e enum para gerenciar solicitações entre professores e alunos
- Implementar serviço e repositório para envio e resposta de solicitações
- Adicionar controlador com endpoints para solicitar e responder vínculo (aceitar ou recusar)
- Usar professor autenticado ao solicitar vínculo, sem receber UUID no caminho

## Testes
- `mvn -q -e test` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a3a046e508327913384112e710d83