### PR TITLE
Permite aluno visualizar suas medidas

### DIFF
--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -4,6 +4,8 @@ import com.example.demo.dto.*;
 import com.example.demo.service.AlunoMedidaService;
 import com.example.demo.service.AlunoObservacaoService;
 import com.example.demo.service.AlunoService;
+import com.example.demo.common.security.SecurityUtils;
+import com.example.demo.common.security.UsuarioLogado;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -19,7 +21,6 @@ import java.util.UUID;
 @Slf4j
 @RestController
 @RequestMapping("/alunos")
-@PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
 public class AlunoController {
     private final AlunoService service;
     private final AlunoMedidaService medidaService;
@@ -34,36 +35,42 @@ public class AlunoController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<String>> criar(@Validated @RequestBody AlunoDTO dto) {
         String msg = service.create(dto);
         return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
     @GetMapping
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<Page<AlunoDTO>>> listar(Pageable pageable) {
         Page<AlunoDTO> page = service.findAll(pageable);
         return ResponseEntity.ok(new ApiResponse<>(true, "Lista de alunos", page, null));
     }
 
     @GetMapping("/{uuid}")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<AlunoDTO>> buscar(@PathVariable UUID uuid) {
         AlunoDTO dto = service.findByUuid(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Aluno encontrado", dto, null));
     }
 
     @PutMapping("/{uuid}")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<String>> atualizar(@PathVariable UUID uuid, @Validated @RequestBody AlunoDTO dto) {
         String msg = service.update(uuid, dto);
         return ResponseEntity.ok(new ApiResponse<>(true, msg, null, null));
     }
 
     @DeleteMapping("/{uuid}")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<Void>> remover(@PathVariable UUID uuid) {
         service.delete(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Aluno removido", null, null));
     }
 
     @PostMapping("/{uuid}/medidas")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<String>> adicionarMedida(@PathVariable UUID uuid,
                                                                @Validated @RequestBody AlunoMedidaDTO dto) {
         String msg = medidaService.adicionarMedida(uuid, dto);
@@ -71,12 +78,22 @@ public class AlunoController {
     }
 
     @GetMapping("/{uuid}/medidas")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<List<AlunoMedidaDTO>>> listarMedidas(@PathVariable UUID uuid) {
         List<AlunoMedidaDTO> lista = medidaService.listarMedidas(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Lista de medidas", lista, null));
     }
 
+    @GetMapping("/me/medidas")
+    @PreAuthorize("hasRole('ALUNO')")
+    public ResponseEntity<ApiResponse<List<AlunoMedidaDTO>>> listarMedidasAlunoLogado() {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogado();
+        List<AlunoMedidaDTO> lista = medidaService.listarMedidas(usuario.getUuid());
+        return ResponseEntity.ok(new ApiResponse<>(true, "Lista de medidas", lista, null));
+    }
+
     @PostMapping("/{uuid}/observacoes")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<String>> adicionarObservacao(@PathVariable UUID uuid,
                                                                    @Validated @RequestBody AlunoObservacaoDTO dto) {
         String msg = observacaoService.adicionarObservacao(uuid, dto);
@@ -84,6 +101,7 @@ public class AlunoController {
     }
 
     @GetMapping("/{uuid}/observacoes")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiResponse<List<AlunoObservacaoDTO>>> listarObservacoes(@PathVariable UUID uuid) {
         List<AlunoObservacaoDTO> lista = observacaoService.listarObservacoes(uuid);
         return ResponseEntity.ok(new ApiResponse<>(true, "Lista de observações", lista, null));

--- a/src/main/java/com/example/demo/service/AlunoMedidaService.java
+++ b/src/main/java/com/example/demo/service/AlunoMedidaService.java
@@ -3,10 +3,15 @@ package com.example.demo.service;
 import com.example.demo.dto.AlunoMedidaDTO;
 import com.example.demo.entity.Aluno;
 import com.example.demo.entity.AlunoMedida;
+import com.example.demo.entity.Usuario;
 import com.example.demo.exception.ApiException;
 import com.example.demo.mapper.AlunoMedidaMapper;
 import com.example.demo.repository.AlunoMedidaRepository;
 import com.example.demo.repository.AlunoRepository;
+import com.example.demo.repository.UsuarioRepository;
+import com.example.demo.common.security.SecurityUtils;
+import com.example.demo.common.security.UsuarioLogado;
+import com.example.demo.domain.enums.Perfil;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,19 +23,25 @@ public class AlunoMedidaService {
 
     private final AlunoMedidaRepository repository;
     private final AlunoRepository alunoRepository;
+    private final UsuarioRepository usuarioRepository;
     private final AlunoMedidaMapper mapper;
 
     public AlunoMedidaService(AlunoMedidaRepository repository,
                               AlunoRepository alunoRepository,
+                              UsuarioRepository usuarioRepository,
                               AlunoMedidaMapper mapper) {
         this.repository = repository;
         this.alunoRepository = alunoRepository;
+        this.usuarioRepository = usuarioRepository;
         this.mapper = mapper;
     }
 
     public String adicionarMedida(UUID alunoUuid, AlunoMedidaDTO dto) {
         Aluno aluno = alunoRepository.findById(alunoUuid)
                 .orElseThrow(() -> new ApiException("Aluno não encontrado"));
+
+        validarMesmaAcademia(aluno);
+
         AlunoMedida medida = mapper.toEntity(dto);
         medida.setAluno(aluno);
         repository.save(medida);
@@ -38,9 +49,29 @@ public class AlunoMedidaService {
     }
 
     public List<AlunoMedidaDTO> listarMedidas(UUID alunoUuid) {
+        Aluno aluno = alunoRepository.findById(alunoUuid)
+                .orElseThrow(() -> new ApiException("Aluno não encontrado"));
+
+        validarMesmaAcademia(aluno);
+
         return repository.findByAlunoUuid(alunoUuid)
                 .stream()
                 .map(mapper::toDto)
                 .collect(Collectors.toList());
+    }
+
+    private void validarMesmaAcademia(Aluno aluno) {
+        UsuarioLogado usuarioLogado = SecurityUtils.getUsuarioLogado();
+        boolean isMaster = usuarioLogado != null && usuarioLogado.possuiPerfil(Perfil.MASTER);
+
+        if (usuarioLogado != null && !isMaster) {
+            Usuario usuario = usuarioRepository.findByUuid(usuarioLogado.getUuid())
+                    .orElseThrow(() -> new ApiException("Usuário precisa ter uma academia associada"));
+
+            if (usuario.getAcademia() == null || aluno.getAcademia() == null
+                    || !usuario.getAcademia().getUuid().equals(aluno.getAcademia().getUuid())) {
+                throw new ApiException("Acesso negado a aluno de outra academia");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Resumo
- Move o endpoint de medidas do aluno logado para a controller existente
- Restringe cada método da controller por perfil e libera alunos para consultar suas próprias medidas

## Testes
- `mvn -q test` *(falhou: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a3a9592b88327be25478fb89dcf3f