### PR TITLE
Permitir cadastro de aluno sem professor obrigatório

### DIFF
--- a/src/main/java/com/example/demo/entity/Aluno.java
+++ b/src/main/java/com/example/demo/entity/Aluno.java
@@ -9,8 +9,8 @@ import java.time.LocalDate;
 @Entity
 @DiscriminatorValue("ALUNO")
 public class Aluno extends Usuario {
-    @ManyToOne
-    @JoinColumn(name = "professor_id")
+    @ManyToOne(optional = true)
+    @JoinColumn(name = "professor_id", nullable = true)
     private Professor professor;
 
     private LocalDate dataMatricula;


### PR DESCRIPTION
## Sumário
- ajusta mapeamento de `Aluno` para permitir professor opcional

## Testes
- `mvn -q test` *(falhou: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a50af8520832792d1469a41f097e8