### PR TITLE
Evita envio de e-mail se cadastro de academia falhar

### DIFF
--- a/src/main/java/com/example/demo/service/AcademiaService.java
+++ b/src/main/java/com/example/demo/service/AcademiaService.java
@@ -8,12 +8,16 @@ import com.example.demo.repository.AcademiaRepository;
 import com.example.demo.domain.enums.Perfil;
 import com.example.demo.common.util.SenhaUtil;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
+@Slf4j
 public class AcademiaService {
     private final AcademiaRepository repository;
     private final AcademiaMapper mapper;
@@ -30,15 +34,29 @@ public class AcademiaService {
 
     @Transactional
     public String create(AcademiaDTO dto) {
-        Academia entity = mapper.toEntity(dto);
-        Usuario admin = entity.getAdmin();
-        String senha = SenhaUtil.gerarSenhaNumerica(6);
-        admin.setSenha(passwordEncoder.encode(senha));
-        admin.setPerfil(Perfil.ADMIN);
-        admin.setAcademia(entity);
-        repository.save(entity);
-        emailService.enviarSenha(admin.getEmail(), senha, entity.getUuid().toString());
-        return "Academia criada com sucesso";
+        try {
+            Academia entity = mapper.toEntity(dto);
+            Usuario admin = entity.getAdmin();
+            String senha = SenhaUtil.gerarSenhaNumerica(6);
+            admin.setSenha(passwordEncoder.encode(senha));
+            admin.setPerfil(Perfil.ADMIN);
+            admin.setAcademia(entity);
+            repository.save(entity);
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    try {
+                        emailService.enviarSenha(admin.getEmail(), senha, entity.getUuid().toString());
+                    } catch (Exception e) {
+                        log.error("Erro ao enviar email", e);
+                    }
+                }
+            });
+            return "Academia criada com sucesso";
+        } catch (Exception e) {
+            log.error("Erro ao criar academia", e);
+            return "Erro ao criar academia";
+        }
     }
 
     public Page<AcademiaDTO> findAll(Pageable pageable) {


### PR DESCRIPTION
## Resumo
- envia o e-mail de senha somente após confirmar o commit da transação
- retorna mensagem de erro quando o cadastro não é concluído

## Testes
- `mvn -q test` *(falhou: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b4b1746808327ae4b38e0788fd6b7