### PR TITLE
Adiciona mecanismo de inativação de usuários e academias

### DIFF
--- a/src/main/java/com/example/demo/common/config/security/UserAuthenticationConfig.java
+++ b/src/main/java/com/example/demo/common/config/security/UserAuthenticationConfig.java
@@ -19,11 +19,16 @@ public class UserAuthenticationConfig {
     @Bean
     public UserDetailsService userDetailsService(UsuarioRepository repository) {
         return username -> repository.findByEmail(username)
+                .filter(usuario -> {
+                    boolean usuarioAtivo = usuario.isAtivo();
+                    boolean academiaAtiva = usuario.getAcademia() == null || usuario.getAcademia().isAtivo();
+                    return usuarioAtivo && academiaAtiva;
+                })
                 .map(usuario -> User.withUsername(usuario.getEmail())
                         .password(usuario.getSenha())
                         .roles(usuario.getPerfil().name())
                         .build())
-                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado ou inativo"));
     }
 
     @Bean

--- a/src/main/java/com/example/demo/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/common/security/filter/JwtAuthenticationFilter.java
@@ -57,12 +57,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (jwtService.isTokenValid(jwt, userDetails)) {
                 var usuario = usuarioRepository.findByEmail(username).orElse(null);
                 if (usuario != null) {
-                    var academiaUuid = usuario.getAcademia() != null ? usuario.getAcademia().getUuid() : null;
-                    var principal = new UsuarioLogado(usuario.getUuid(), academiaUuid, usuario.getPerfil());
-                    var authToken = new UsernamePasswordAuthenticationToken(
-                            principal, null, userDetails.getAuthorities());
-                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                    boolean usuarioAtivo = usuario.isAtivo();
+                    boolean academiaAtiva = usuario.getAcademia() == null || usuario.getAcademia().isAtivo();
+                    if (usuarioAtivo && academiaAtiva) {
+                        var academiaUuid = usuario.getAcademia() != null ? usuario.getAcademia().getUuid() : null;
+                        var principal = new UsuarioLogado(usuario.getUuid(), academiaUuid, usuario.getPerfil());
+                        var authToken = new UsernamePasswordAuthenticationToken(
+                                principal, null, userDetails.getAuthorities());
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+                    }
                 }
             }
         }

--- a/src/main/java/com/example/demo/controller/UsuarioController.java
+++ b/src/main/java/com/example/demo/controller/UsuarioController.java
@@ -3,10 +3,8 @@ package com.example.demo.controller;
 import com.example.demo.dto.UsuarioDTO;
 import com.example.demo.service.UsuarioService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import java.util.UUID;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Usuários")
@@ -23,5 +21,10 @@ public class UsuarioController {
     @PostMapping("/master")
     public ResponseEntity<String> criarMaster(@RequestBody UsuarioDTO dto) {
         return ResponseEntity.ok(service.criarUsuarioMaster(dto));
+    }
+
+    @PutMapping("/{uuid}/ativo")
+    public ResponseEntity<String> alterarAtivo(@PathVariable UUID uuid, @RequestParam boolean ativo) {
+        return ResponseEntity.ok(service.alterarAtivo(uuid, ativo));
     }
 }

--- a/src/main/java/com/example/demo/dto/AlunoDTO.java
+++ b/src/main/java/com/example/demo/dto/AlunoDTO.java
@@ -1,13 +1,10 @@
 package com.example.demo.dto;
 
-import com.example.demo.entity.StatusAluno;
-
 import java.time.LocalDate;
 import java.util.UUID;
 
 public class AlunoDTO extends UsuarioDTO {
     private LocalDate dataMatricula;
-    private StatusAluno status;
     private UUID professorUuid;
 
     public LocalDate getDataMatricula() {
@@ -16,14 +13,6 @@ public class AlunoDTO extends UsuarioDTO {
 
     public void setDataMatricula(LocalDate dataMatricula) {
         this.dataMatricula = dataMatricula;
-    }
-
-    public StatusAluno getStatus() {
-        return status;
-    }
-
-    public void setStatus(StatusAluno status) {
-        this.status = status;
     }
 
     public UUID getProfessorUuid() {

--- a/src/main/java/com/example/demo/entity/Academia.java
+++ b/src/main/java/com/example/demo/entity/Academia.java
@@ -23,6 +23,9 @@ public class Academia {
     private String bairro;
     private String telefone;
 
+    @Column(nullable = false)
+    private boolean ativo = true;
+
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "admin_uuid", referencedColumnName = "uuid", nullable = false)
     private Usuario admin;

--- a/src/main/java/com/example/demo/entity/Aluno.java
+++ b/src/main/java/com/example/demo/entity/Aluno.java
@@ -14,7 +14,4 @@ public class Aluno extends Usuario {
     private Professor professor;
 
     private LocalDate dataMatricula;
-
-    @Enumerated(EnumType.STRING)
-    private StatusAluno status = StatusAluno.ATIVO;
 }

--- a/src/main/java/com/example/demo/entity/StatusAluno.java
+++ b/src/main/java/com/example/demo/entity/StatusAluno.java
@@ -1,6 +1,0 @@
-package com.example.demo.entity;
-
-public enum StatusAluno {
-    ATIVO,
-    INATIVO
-}

--- a/src/main/java/com/example/demo/entity/Usuario.java
+++ b/src/main/java/com/example/demo/entity/Usuario.java
@@ -46,6 +46,9 @@ public class Usuario {
     @Column(nullable = false)
     private Perfil perfil;
 
+    @Column(nullable = false)
+    private boolean ativo = true;
+
     @ManyToOne
     @JoinColumn(name = "academia_uuid")
     private Academia academia;

--- a/src/main/java/com/example/demo/service/AlunoService.java
+++ b/src/main/java/com/example/demo/service/AlunoService.java
@@ -127,7 +127,6 @@ public class AlunoService {
         entity.setUf(dto.getUf());
         entity.setCidade(dto.getCidade());
         entity.setDataMatricula(dto.getDataMatricula());
-        entity.setStatus(dto.getStatus());
         if (dto.getProfessorUuid() != null) {
             Professor professor = professorRepository.findById(dto.getProfessorUuid())
                     .orElseThrow(() -> new ApiException("Professor não encontrado"));

--- a/src/main/java/com/example/demo/service/UsuarioService.java
+++ b/src/main/java/com/example/demo/service/UsuarioService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 public class UsuarioService {
@@ -83,6 +84,16 @@ public class UsuarioService {
                     usuario.setSenha(passwordEncoder.encode(novaSenha));
                     repository.save(usuario);
                     return "Senha alterada com sucesso";
+                }).orElse("Usuário não encontrado");
+    }
+
+    @Transactional
+    public String alterarAtivo(UUID uuid, boolean ativo) {
+        return repository.findByUuid(uuid)
+                .map(usuario -> {
+                    usuario.setAtivo(ativo);
+                    repository.save(usuario);
+                    return ativo ? "Usuário ativado" : "Usuário desativado";
                 }).orElse("Usuário não encontrado");
     }
 


### PR DESCRIPTION
## Resumo
- Inclui campo `ativo` em `Usuario` e `Academia`
- Cria serviço e endpoint para ativar ou desativar usuários
- Bloqueia autenticação e acesso quando usuário ou academia estiverem inativos
- Remove enum de status em `Aluno`, utilizando apenas a flag `ativo`

## Testes
- `./mvnw -q test` *(falhou: Failed to fetch maven)*
- `mvn -q test` *(falhou: Network is unreachable ao resolver dependências)*

------
https://chatgpt.com/codex/tasks/task_e_689b506f91308327a6c9c5fd831274b2