### PR TITLE
Include user details in JWT token

### DIFF
--- a/src/main/java/com/example/demo/common/security/JwtService.java
+++ b/src/main/java/com/example/demo/common/security/JwtService.java
@@ -27,7 +27,12 @@ public class JwtService {
     private long refreshExpiration;
 
     public String generateToken(UserDetails userDetails) {
+        return generateToken(Map.of(), userDetails);
+    }
+
+    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
         return Jwts.builder()
+                .setClaims(extraClaims)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + expiration))

--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 
 @Tag(name = "Autenticação")
 @RestController
@@ -46,8 +47,18 @@ public class AuthController {
                 if (usuario != null) {
                     usuarioService.registrarUltimoAcesso(usuario);
                 }
-                String token = jwtService.generateToken(userDetails);
-                AuthResponse resp = new AuthResponse(token, primeiroAcesso);
+                Map<String, Object> claims = Map.of(
+                        "nome", usuario.getNome(),
+                        "email", usuario.getEmail(),
+                        "perfil", usuario.getPerfil().name()
+                );
+                String token = jwtService.generateToken(claims, userDetails);
+                AuthResponse resp = new AuthResponse(
+                        token,
+                        primeiroAcesso,
+                        usuario.getNome(),
+                        usuario.getEmail(),
+                        usuario.getPerfil().name());
                 return ResponseEntity.ok(new ApiResponse<>(true, "Autenticado", resp, null));
             }
         } catch (Exception e) {

--- a/src/main/java/com/example/demo/dto/AuthResponse.java
+++ b/src/main/java/com/example/demo/dto/AuthResponse.java
@@ -3,13 +3,19 @@ package com.example.demo.dto;
 public class AuthResponse {
     private String token;
     private boolean primeiroAcesso;
+    private String nome;
+    private String email;
+    private String perfil;
 
     public AuthResponse() {
     }
 
-    public AuthResponse(String token, boolean primeiroAcesso) {
+    public AuthResponse(String token, boolean primeiroAcesso, String nome, String email, String perfil) {
         this.token = token;
         this.primeiroAcesso = primeiroAcesso;
+        this.nome = nome;
+        this.email = email;
+        this.perfil = perfil;
     }
 
     public String getToken() {
@@ -26,5 +32,29 @@ public class AuthResponse {
 
     public void setPrimeiroAcesso(boolean primeiroAcesso) {
         this.primeiroAcesso = primeiroAcesso;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPerfil() {
+        return perfil;
+    }
+
+    public void setPerfil(String perfil) {
+        this.perfil = perfil;
     }
 }


### PR DESCRIPTION
## Summary
- add overloaded JwtService.generateToken supporting extra claims
- embed user name, email and profile in login token and response

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bd758bcc48327b0b04622f44774bc