### PR TITLE
feat: add filters to exercise search

### DIFF
--- a/src/main/java/com/example/demo/controller/ExercicioController.java
+++ b/src/main/java/com/example/demo/controller/ExercicioController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import com.example.demo.common.response.ApiReturn;
 import com.example.demo.dto.ExercicioDTO;
+import com.example.demo.entity.Musculo;
 import com.example.demo.service.ExercicioService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,7 +30,9 @@ public class ExercicioController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiReturn<Page<ExercicioDTO>>> listar(Pageable pageable) {
-        return ResponseEntity.ok(ApiReturn.of(service.findAll(pageable)));
+    public ResponseEntity<ApiReturn<Page<ExercicioDTO>>> listar(@RequestParam(required = false) String nome,
+                                                                @RequestParam(required = false) Musculo musculo,
+                                                                Pageable pageable) {
+        return ResponseEntity.ok(ApiReturn.of(service.find(nome, musculo, pageable)));
     }
 }

--- a/src/main/java/com/example/demo/repository/ExercicioRepository.java
+++ b/src/main/java/com/example/demo/repository/ExercicioRepository.java
@@ -1,6 +1,7 @@
 package com.example.demo.repository;
 
 import com.example.demo.entity.Exercicio;
+import com.example.demo.entity.Musculo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,26 @@ public interface ExercicioRepository extends JpaRepository<Exercicio, UUID> {
     Page<Exercicio> findByAcademiaIsNullOrAcademiaUuid(@Param("academiaUuid") UUID academiaUuid, Pageable pageable);
 
     Page<Exercicio> findByAcademiaUuid(UUID academiaUuid, Pageable pageable);
+
+    @Query("""
+            SELECT e
+            FROM Exercicio e
+            WHERE (:nome IS NULL OR LOWER(e.nome) LIKE LOWER(CONCAT('%', :nome, '%')))
+              AND (:musculo IS NULL OR e.musculo = :musculo)
+        """)
+    Page<Exercicio> findAllByNomeContainingIgnoreCaseAndMusculo(@Param("nome") String nome,
+                                                                @Param("musculo") Musculo musculo,
+                                                                Pageable pageable);
+
+    @Query("""
+            SELECT e
+            FROM Exercicio e
+            WHERE (e.academia IS NULL OR e.academia.uuid = :academiaUuid)
+              AND (:nome IS NULL OR LOWER(e.nome) LIKE LOWER(CONCAT('%', :nome, '%')))
+              AND (:musculo IS NULL OR e.musculo = :musculo)
+        """)
+    Page<Exercicio> findByAcademiaAndFilters(@Param("academiaUuid") UUID academiaUuid,
+                                             @Param("nome") String nome,
+                                             @Param("musculo") Musculo musculo,
+                                             Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/ExercicioService.java
+++ b/src/main/java/com/example/demo/service/ExercicioService.java
@@ -2,6 +2,7 @@ package com.example.demo.service;
 
 import com.example.demo.dto.ExercicioDTO;
 import com.example.demo.entity.Exercicio;
+import com.example.demo.entity.Musculo;
 import com.example.demo.mapper.ExercicioMapper;
 import com.example.demo.repository.ExercicioRepository;
 import com.example.demo.repository.UsuarioRepository;
@@ -48,13 +49,13 @@ public class ExercicioService {
         return "Exercício criado com sucesso";
     }
 
-    public Page<ExercicioDTO> findAll(Pageable pageable) {
+    public Page<ExercicioDTO> find(String nome, Musculo musculo, Pageable pageable) {
         UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
 
         boolean isMaster = usuario != null && usuario.possuiPerfil(Perfil.MASTER);
 
         if (isMaster) {
-            return repository.findAll(pageable)
+            return repository.findAllByNomeContainingIgnoreCaseAndMusculo(nome, musculo, pageable)
                     .map(mapper::toDto);
         } else {
             Usuario usuarioEntity = usuarioRepository.findByUuid(usuario.getUuid())
@@ -65,7 +66,7 @@ public class ExercicioService {
                 throw new IllegalArgumentException("Usuário precisa ter uma academia associada");
             }
 
-            return repository.findByAcademiaIsNullOrAcademiaUuid(academia.getUuid(), pageable)
+            return repository.findByAcademiaAndFilters(academia.getUuid(), nome, musculo, pageable)
                     .map(mapper::toDto);
         }
     }


### PR DESCRIPTION
## Summary
- allow exercise listing to filter by partial name or muscle
- extend service and repository with methods supporting these filters

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d2123198c8327bc0150f891299c09