### PR TITLE
Track workout history with repetitions and load

### DIFF
--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -43,6 +43,12 @@ public class FichaTreinoController {
         return ResponseEntity.ok(ApiReturn.of(fichas));
     }
 
+    @GetMapping("/historico/{alunoUuid}")
+    public ResponseEntity<ApiReturn<List<FichaTreinoDTO>>> historicoPorAluno(@PathVariable UUID alunoUuid) {
+        List<FichaTreinoDTO> fichas = service.findHistoricoByAluno(alunoUuid);
+        return ResponseEntity.ok(ApiReturn.of(fichas));
+    }
+
     @PostMapping("/preset/{presetUuid}/aluno/{alunoUuid}")
     public ResponseEntity<ApiReturn<String>> atribuirPreset(@PathVariable UUID presetUuid, @PathVariable UUID alunoUuid) {
         String msg = service.assignPreset(presetUuid, alunoUuid);

--- a/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
@@ -9,7 +9,7 @@ public class FichaTreinoDTO {
     private UUID professorUuid;
     private String categoria;
     private boolean preset;
-    private List<UUID> exerciciosUuids;
+    private List<FichaTreinoExercicioDTO> exercicios;
 
     public UUID getUuid() {
         return uuid;
@@ -51,11 +51,11 @@ public class FichaTreinoDTO {
         this.preset = preset;
     }
 
-    public List<UUID> getExerciciosUuids() {
-        return exerciciosUuids;
+    public List<FichaTreinoExercicioDTO> getExercicios() {
+        return exercicios;
     }
 
-    public void setExerciciosUuids(List<UUID> exerciciosUuids) {
-        this.exerciciosUuids = exerciciosUuids;
+    public void setExercicios(List<FichaTreinoExercicioDTO> exercicios) {
+        this.exercicios = exercicios;
     }
 }

--- a/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
@@ -1,0 +1,33 @@
+package com.example.demo.dto;
+
+import java.util.UUID;
+
+public class FichaTreinoExercicioDTO {
+    private UUID exercicioUuid;
+    private Integer repeticoes;
+    private Double carga;
+
+    public UUID getExercicioUuid() {
+        return exercicioUuid;
+    }
+
+    public void setExercicioUuid(UUID exercicioUuid) {
+        this.exercicioUuid = exercicioUuid;
+    }
+
+    public Integer getRepeticoes() {
+        return repeticoes;
+    }
+
+    public void setRepeticoes(Integer repeticoes) {
+        this.repeticoes = repeticoes;
+    }
+
+    public Double getCarga() {
+        return carga;
+    }
+
+    public void setCarga(Double carga) {
+        this.carga = carga;
+    }
+}

--- a/src/main/java/com/example/demo/entity/FichaTreinoExercicio.java
+++ b/src/main/java/com/example/demo/entity/FichaTreinoExercicio.java
@@ -3,31 +3,29 @@ package com.example.demo.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Data
 @Entity
-public class FichaTreino {
+@Table(name = "ficha_exercicio")
+public class FichaTreinoExercicio {
     @Id
     @Column(nullable = false, unique = true, updatable = false)
     private UUID uuid;
 
-    @ManyToOne
-    private Aluno aluno;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ficha_uuid", referencedColumnName = "uuid")
+    private FichaTreino ficha;
 
-    @ManyToOne
-    private Professor professor;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "exercicio_uuid", referencedColumnName = "uuid")
+    private Exercicio exercicio;
 
     @Column(nullable = false)
-    private String categoria;
+    private Integer repeticoes;
 
     @Column(nullable = false)
-    private boolean preset;
-
-    @OneToMany(mappedBy = "ficha", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FichaTreinoExercicio> exercicios = new ArrayList<>();
+    private Double carga;
 
     @PrePersist
     private void gerarUuid() {

--- a/src/main/java/com/example/demo/entity/FichaTreinoHistorico.java
+++ b/src/main/java/com/example/demo/entity/FichaTreinoHistorico.java
@@ -1,0 +1,34 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Entity
+public class FichaTreinoHistorico {
+    @Id
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID uuid;
+
+    @ManyToOne(optional = false)
+    private Aluno aluno;
+
+    @ManyToOne(optional = false)
+    private FichaTreino ficha;
+
+    @Column(nullable = false)
+    private LocalDateTime dataCadastro;
+
+    @PrePersist
+    private void prePersist() {
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+        if (dataCadastro == null) {
+            dataCadastro = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
+++ b/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
@@ -1,8 +1,9 @@
 package com.example.demo.mapper;
 
 import com.example.demo.dto.FichaTreinoDTO;
-import com.example.demo.entity.Exercicio;
+import com.example.demo.dto.FichaTreinoExercicioDTO;
 import com.example.demo.entity.FichaTreino;
+import com.example.demo.entity.FichaTreinoExercicio;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
@@ -27,11 +28,19 @@ public class FichaTreinoMapper {
         }
         dto.setCategoria(ficha.getCategoria());
         dto.setPreset(ficha.isPreset());
-        dto.setExerciciosUuids(ficha.getExercicios().stream().map(Exercicio::getUuid).collect(Collectors.toList()));
+        dto.setExercicios(ficha.getExercicios().stream().map(this::toExercicioDto).collect(Collectors.toList()));
         return dto;
     }
 
     public FichaTreino toEntity(FichaTreinoDTO dto) {
         return mapper.map(dto, FichaTreino.class);
+    }
+
+    private FichaTreinoExercicioDTO toExercicioDto(FichaTreinoExercicio exercicio) {
+        FichaTreinoExercicioDTO dto = new FichaTreinoExercicioDTO();
+        dto.setExercicioUuid(exercicio.getExercicio().getUuid());
+        dto.setRepeticoes(exercicio.getRepeticoes());
+        dto.setCarga(exercicio.getCarga());
+        return dto;
     }
 }

--- a/src/main/java/com/example/demo/repository/FichaTreinoHistoricoRepository.java
+++ b/src/main/java/com/example/demo/repository/FichaTreinoHistoricoRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.FichaTreinoHistorico;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FichaTreinoHistoricoRepository extends JpaRepository<FichaTreinoHistorico, UUID> {
+    List<FichaTreinoHistorico> findByAluno_UuidOrderByDataCadastroDesc(UUID alunoUuid);
+}


### PR DESCRIPTION
## Summary
- Include repetitions and load for each exercise in a workout sheet
- Persist workout sheet history per student and expose retrieval endpoint

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f81620c488327b248573857f682f0