### PR TITLE
refactor: inline service calls in controllers

### DIFF
--- a/src/main/java/com/example/demo/controller/AcademiaController.java
+++ b/src/main/java/com/example/demo/controller/AcademiaController.java
@@ -32,8 +32,7 @@ public class AcademiaController {
     @GetMapping
     public ResponseEntity<ApiReturn<Page<AcademiaDTO>>> listar(@RequestParam(required = false) String nome,
                                                                Pageable pageable) {
-        Page<AcademiaDTO> page = service.findAll(nome, pageable);
-        return ResponseEntity.ok(ApiReturn.of(page));
+        return ResponseEntity.ok(ApiReturn.of(service.findAll(nome, pageable)));
     }
 
     @GetMapping("/{uuid}")

--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -6,7 +6,6 @@ import com.example.demo.service.AlunoMedidaService;
 import com.example.demo.service.AlunoObservacaoService;
 import com.example.demo.service.AlunoService;
 import com.example.demo.common.security.SecurityUtils;
-import com.example.demo.common.security.UsuarioLogado;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -51,8 +50,7 @@ public class AlunoController {
     @GetMapping("/{uuid}")
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiReturn<AlunoDTO>> buscar(@PathVariable UUID uuid) {
-        AlunoDTO dto = service.findByUuid(uuid);
-        return ResponseEntity.ok(ApiReturn.of(dto));
+        return ResponseEntity.ok(ApiReturn.of(service.findByUuid(uuid)));
     }
 
     @PutMapping("/{uuid}")
@@ -72,37 +70,31 @@ public class AlunoController {
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiReturn<String>> adicionarMedida(@PathVariable UUID uuid,
                                                              @Validated @RequestBody AlunoMedidaDTO dto) {
-        String msg = medidaService.adicionarMedida(uuid, dto);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(medidaService.adicionarMedida(uuid, dto)));
     }
 
     @GetMapping("/{uuid}/medidas")
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiReturn<List<AlunoMedidaDTO>>> listarMedidas(@PathVariable UUID uuid) {
-        List<AlunoMedidaDTO> lista = medidaService.listarMedidas(uuid);
-        return ResponseEntity.ok(ApiReturn.of(lista));
+        return ResponseEntity.ok(ApiReturn.of(medidaService.listarMedidas(uuid)));
     }
 
     @GetMapping("/me/medidas")
     @PreAuthorize("hasRole('ALUNO')")
     public ResponseEntity<ApiReturn<List<AlunoMedidaDTO>>> listarMedidasAlunoLogado() {
-        UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
-        List<AlunoMedidaDTO> lista = medidaService.listarMedidas(usuario.getUuid());
-        return ResponseEntity.ok(ApiReturn.of(lista));
+        return ResponseEntity.ok(ApiReturn.of(medidaService.listarMedidas(SecurityUtils.getUsuarioLogadoDetalhes().getUuid())));
     }
 
     @PostMapping("/{uuid}/observacoes")
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiReturn<String>> adicionarObservacao(@PathVariable UUID uuid,
                                                                  @Validated @RequestBody AlunoObservacaoDTO dto) {
-        String msg = observacaoService.adicionarObservacao(uuid, dto);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(observacaoService.adicionarObservacao(uuid, dto)));
     }
 
     @GetMapping("/{uuid}/observacoes")
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiReturn<List<AlunoObservacaoDTO>>> listarObservacoes(@PathVariable UUID uuid) {
-        List<AlunoObservacaoDTO> lista = observacaoService.listarObservacoes(uuid);
-        return ResponseEntity.ok(ApiReturn.of(lista));
+        return ResponseEntity.ok(ApiReturn.of(observacaoService.listarObservacoes(uuid)));
     }
 }

--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -53,14 +53,12 @@ public class AuthController {
                         "email", usuario.getEmail(),
                         "perfil", usuario.getPerfil().name()
                 );
-                String token = jwtService.generateToken(claims, userDetails);
-                AuthResponse resp = new AuthResponse(
-                        token,
+                return ResponseEntity.ok(ApiReturn.of(new AuthResponse(
+                        jwtService.generateToken(claims, userDetails),
                         primeiroAcesso,
                         usuario.getNome(),
                         usuario.getEmail(),
-                        usuario.getPerfil().name());
-                return ResponseEntity.ok(ApiReturn.of(resp));
+                        usuario.getPerfil().name())));
             }
         } catch (Exception e) {
             return ResponseEntity.status(401)
@@ -72,13 +70,11 @@ public class AuthController {
 
     @PostMapping("/reenviar-senha")
     public ResponseEntity<ApiReturn<String>> reenviarSenha(@RequestBody ReenviarSenhaDTO dto) {
-        String msg = usuarioService.reenviarSenha(dto.getLogin());
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(usuarioService.reenviarSenha(dto.getLogin())));
     }
 
     @PostMapping("/alterar-senha")
     public ResponseEntity<ApiReturn<String>> alterarSenha(@RequestBody AlterarSenhaDTO dto) {
-        String msg = usuarioService.alterarSenha(dto.getLogin(), dto.getSenhaAtual(), dto.getNovaSenha());
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(usuarioService.alterarSenha(dto.getLogin(), dto.getSenhaAtual(), dto.getNovaSenha())));
     }
 }

--- a/src/main/java/com/example/demo/controller/ExercicioController.java
+++ b/src/main/java/com/example/demo/controller/ExercicioController.java
@@ -27,8 +27,7 @@ public class ExercicioController {
 
     @PostMapping
     public ResponseEntity<ApiReturn<String>> criar(@Validated @RequestBody ExercicioDTO dto) {
-        String msg = service.create(dto);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(service.create(dto)));
     }
 
     @GetMapping

--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -37,8 +37,7 @@ public class FichaTreinoController {
 
     @GetMapping("/aluno/{alunoUuid}")
     public ResponseEntity<ApiReturn<List<FichaTreinoDTO>>> listarPorAluno(@PathVariable UUID alunoUuid) {
-        List<FichaTreinoDTO> fichas = service.findByAluno(alunoUuid);
-        return ResponseEntity.ok(ApiReturn.of(fichas));
+        return ResponseEntity.ok(ApiReturn.of(service.findByAluno(alunoUuid)));
     }
 
     @GetMapping("/historico/{alunoUuid}")
@@ -48,7 +47,6 @@ public class FichaTreinoController {
 
     @PostMapping("/preset/{presetUuid}/aluno/{alunoUuid}")
     public ResponseEntity<ApiReturn<String>> atribuirPreset(@PathVariable UUID presetUuid, @PathVariable UUID alunoUuid) {
-        String msg = service.assignPreset(presetUuid, alunoUuid);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(service.assignPreset(presetUuid, alunoUuid)));
     }
 }

--- a/src/main/java/com/example/demo/controller/ProfessorController.java
+++ b/src/main/java/com/example/demo/controller/ProfessorController.java
@@ -25,27 +25,23 @@ public class ProfessorController {
 
     @PostMapping
     public ResponseEntity<ApiReturn<String>> criar(@Validated @RequestBody ProfessorDTO dto) {
-        String msg = service.create(dto);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(service.create(dto)));
     }
 
     @GetMapping
     public ResponseEntity<ApiReturn<Page<ProfessorDTO>>> listar(@RequestParam(required = false) String nome,
                                                                 Pageable pageable) {
-        Page<ProfessorDTO> page = service.findAll(nome, pageable);
-        return ResponseEntity.ok(ApiReturn.of(page));
+        return ResponseEntity.ok(ApiReturn.of(service.findAll(nome, pageable)));
     }
 
     @GetMapping("/{uuid}")
     public ResponseEntity<ApiReturn<ProfessorDTO>> buscar(@PathVariable UUID uuid) {
-        ProfessorDTO dto = service.findByUuid(uuid);
-        return ResponseEntity.ok(ApiReturn.of(dto));
+        return ResponseEntity.ok(ApiReturn.of(service.findByUuid(uuid)));
     }
 
     @PutMapping("/{uuid}")
     public ResponseEntity<ApiReturn<String>> atualizar(@PathVariable UUID uuid, @Validated @RequestBody ProfessorDTO dto) {
-        String msg = service.update(uuid, dto);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(service.update(uuid, dto)));
     }
 
     @DeleteMapping("/{uuid}")

--- a/src/main/java/com/example/demo/controller/SolicitacaoController.java
+++ b/src/main/java/com/example/demo/controller/SolicitacaoController.java
@@ -25,22 +25,19 @@ public class SolicitacaoController {
     @PostMapping("/alunos/{alunoUuid}")
     @PreAuthorize("hasRole('PROFESSOR')")
     public ResponseEntity<ApiReturn<String>> solicitar(@PathVariable UUID alunoUuid) {
-        String msg = service.solicitar(alunoUuid);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(service.solicitar(alunoUuid)));
     }
 
     @PostMapping("/{uuid}/responder")
     @PreAuthorize("hasRole('ALUNO')")
     public ResponseEntity<ApiReturn<String>> responder(@PathVariable UUID uuid,
                                                        @RequestParam boolean aceita) {
-        String msg = service.responder(uuid, aceita);
-        return ResponseEntity.ok(ApiReturn.of(msg));
+        return ResponseEntity.ok(ApiReturn.of(service.responder(uuid, aceita)));
     }
 
     @GetMapping("/alunos/{alunoUuid}")
     @PreAuthorize("hasRole('ALUNO')")
     public ResponseEntity<ApiReturn<List<SolicitacaoDTO>>> listarPendentes(@PathVariable UUID alunoUuid) {
-        List<SolicitacaoDTO> lista = service.listarPendentes(alunoUuid);
-        return ResponseEntity.ok(ApiReturn.of(lista));
+        return ResponseEntity.ok(ApiReturn.of(service.listarPendentes(alunoUuid)));
     }
 }


### PR DESCRIPTION
## Summary
- return service responses directly in controllers instead of assigning to local variables
- streamline auth endpoints by inlining password service calls

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fb869c020832780c51051cf2f9bbf