### PR TITLE
feat: seed database on startup

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.default_schema=${DB_SCHEME}
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
 
 
 # Pool de Conexões (HikariCP - Padrão do Spring Boot)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO usuario (uuid, nome, cpf, senha, perfil, ativo, tipo)
+VALUES ('00000000-0000-0000-0000-000000000001', 'Administrador', '00000000000', 'admin', 'ADMIN', true, 'Usuario');


### PR DESCRIPTION
## Summary
- add default admin user via data.sql
- configure database initialization to always run

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689fd02d28c08327b0246d1ac93d0d71