### PR TITLE
feat: list professor pending solicitations

### DIFF
--- a/src/main/java/com/example/demo/controller/SolicitacaoController.java
+++ b/src/main/java/com/example/demo/controller/SolicitacaoController.java
@@ -40,4 +40,10 @@ public class SolicitacaoController {
     public ResponseEntity<ApiReturn<List<SolicitacaoDTO>>> listarPendentes(@PathVariable UUID alunoUuid) {
         return ResponseEntity.ok(ApiReturn.of(service.listarPendentes(alunoUuid)));
     }
+
+    @GetMapping("/professores")
+    @PreAuthorize("hasRole('PROFESSOR')")
+    public ResponseEntity<ApiReturn<List<SolicitacaoDTO>>> listarPendentesProfessor() {
+        return ResponseEntity.ok(ApiReturn.of(service.listarPendentesProfessor()));
+    }
 }

--- a/src/main/java/com/example/demo/repository/SolicitacaoRepository.java
+++ b/src/main/java/com/example/demo/repository/SolicitacaoRepository.java
@@ -9,4 +9,5 @@ import java.util.UUID;
 
 public interface SolicitacaoRepository extends JpaRepository<Solicitacao, UUID> {
     List<Solicitacao> findByAlunoUuidAndStatus(UUID alunoUuid, StatusSolicitacao status);
+    List<Solicitacao> findByProfessorUuidAndStatus(UUID professorUuid, StatusSolicitacao status);
 }

--- a/src/main/java/com/example/demo/service/SolicitacaoService.java
+++ b/src/main/java/com/example/demo/service/SolicitacaoService.java
@@ -80,4 +80,16 @@ public class SolicitacaoService {
                 .map(mapper::toDto)
                 .collect(Collectors.toList());
     }
+
+    public List<SolicitacaoDTO> listarPendentesProfessor() {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
+        if (usuario == null) {
+            throw new ApiException("Usuário não autenticado");
+        }
+
+        return repository.findByProfessorUuidAndStatus(usuario.getUuid(), StatusSolicitacao.PENDENTE)
+                .stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## Summary
- allow query of pending solicitations for authenticated professor
- expose new REST endpoint for professors to list pending requests

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven distribution)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fec4a275483278f3f09c60a4be0cf