### PR TITLE
feat: restrict student access by academy

### DIFF
--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -47,6 +47,13 @@ public class AlunoController {
         return ResponseEntity.ok(ApiReturn.of(service.findAll(nome, pageable)));
     }
 
+    @GetMapping("/disponiveis")
+    @PreAuthorize("hasRole('PROFESSOR')")
+    public ResponseEntity<ApiReturn<Page<AlunoDTO>>> listarDisponiveis(@RequestParam(required = false) String nome,
+                                                                       Pageable pageable) {
+        return ResponseEntity.ok(ApiReturn.of(service.findAllNotFromLoggedProfessor(nome, pageable)));
+    }
+
     @GetMapping("/{uuid}")
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
     public ResponseEntity<ApiReturn<AlunoDTO>> buscar(@PathVariable UUID uuid) {

--- a/src/main/java/com/example/demo/repository/AlunoRepository.java
+++ b/src/main/java/com/example/demo/repository/AlunoRepository.java
@@ -4,6 +4,7 @@ import com.example.demo.entity.Aluno;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.UUID;
 
@@ -13,5 +14,12 @@ public interface AlunoRepository extends JpaRepository<Aluno, UUID> {
     Page<Aluno> findByNomeContainingIgnoreCase(String nome, Pageable pageable);
 
     Page<Aluno> findByAcademiaUuidAndNomeContainingIgnoreCase(UUID uuid, String nome, Pageable pageable);
+
     Page<Aluno> findByProfessorUuidAndAcademiaUuid(UUID professorUuid, String escolaUuid, Pageable pageable);
+
+    @Query("SELECT a FROM Aluno a WHERE a.academia.uuid = :academiaUuid AND (a.professor IS NULL OR a.professor.uuid <> :professorUuid)")
+    Page<Aluno> findByAcademiaUuidAndProfessorUuidNotOrProfessorIsNull(UUID academiaUuid, UUID professorUuid, Pageable pageable);
+
+    @Query("SELECT a FROM Aluno a WHERE a.academia.uuid = :academiaUuid AND (a.professor IS NULL OR a.professor.uuid <> :professorUuid) AND LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))")
+    Page<Aluno> findByAcademiaUuidAndProfessorUuidNotOrProfessorIsNullAndNomeContainingIgnoreCase(UUID academiaUuid, UUID professorUuid, String nome, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/AlunoObservacaoService.java
+++ b/src/main/java/com/example/demo/service/AlunoObservacaoService.java
@@ -3,10 +3,15 @@ package com.example.demo.service;
 import com.example.demo.dto.AlunoObservacaoDTO;
 import com.example.demo.entity.Aluno;
 import com.example.demo.entity.AlunoObservacao;
+import com.example.demo.entity.Usuario;
 import com.example.demo.exception.ApiException;
 import com.example.demo.mapper.AlunoObservacaoMapper;
 import com.example.demo.repository.AlunoObservacaoRepository;
 import com.example.demo.repository.AlunoRepository;
+import com.example.demo.repository.UsuarioRepository;
+import com.example.demo.common.security.SecurityUtils;
+import com.example.demo.common.security.UsuarioLogado;
+import com.example.demo.domain.enums.Perfil;
 import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 
@@ -19,13 +24,16 @@ public class AlunoObservacaoService {
 
     private final AlunoObservacaoRepository repository;
     private final AlunoRepository alunoRepository;
+    private final UsuarioRepository usuarioRepository;
     private final AlunoObservacaoMapper mapper;
 
     public AlunoObservacaoService(AlunoObservacaoRepository repository,
                                   AlunoRepository alunoRepository,
+                                  UsuarioRepository usuarioRepository,
                                   AlunoObservacaoMapper mapper) {
         this.repository = repository;
         this.alunoRepository = alunoRepository;
+        this.usuarioRepository = usuarioRepository;
         this.mapper = mapper;
     }
 
@@ -33,6 +41,7 @@ public class AlunoObservacaoService {
     public String adicionarObservacao(UUID alunoUuid, AlunoObservacaoDTO dto) {
         Aluno aluno = alunoRepository.findById(alunoUuid)
                 .orElseThrow(() -> new ApiException("Aluno não encontrado"));
+        validarMesmaAcademia(aluno);
         AlunoObservacao obs = mapper.toEntity(dto);
         obs.setAluno(aluno);
         repository.save(obs);
@@ -40,9 +49,27 @@ public class AlunoObservacaoService {
     }
 
     public List<AlunoObservacaoDTO> listarObservacoes(UUID alunoUuid) {
+        Aluno aluno = alunoRepository.findById(alunoUuid)
+                .orElseThrow(() -> new ApiException("Aluno não encontrado"));
+        validarMesmaAcademia(aluno);
         return repository.findByAlunoUuid(alunoUuid)
                 .stream()
                 .map(mapper::toDto)
                 .collect(Collectors.toList());
+    }
+
+    private void validarMesmaAcademia(Aluno aluno) {
+        UsuarioLogado usuarioLogado = SecurityUtils.getUsuarioLogadoDetalhes();
+        boolean isMaster = usuarioLogado != null && usuarioLogado.possuiPerfil(Perfil.MASTER);
+
+        if (usuarioLogado != null && !isMaster) {
+            Usuario usuario = usuarioRepository.findByUuid(usuarioLogado.getUuid())
+                    .orElseThrow(() -> new ApiException("Usuário precisa ter uma academia associada"));
+
+            if (usuario.getAcademia() == null || aluno.getAcademia() == null
+                    || !usuario.getAcademia().getUuid().equals(aluno.getAcademia().getUuid())) {
+                throw new ApiException("Acesso negado a aluno de outra academia");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add endpoint for professors to list students not assigned to them within their academy
- enforce academy validation when retrieving, updating or deleting students and when managing observations

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ff2eadd108327b0a5a5ef3b04da45