### PR TITLE
Add endpoint to retrieve workout sheet training details

### DIFF
--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -36,6 +36,11 @@ public class FichaTreinoController {
         return ResponseEntity.ok(ApiReturn.of(service.findAll(pageable)));
     }
 
+    @GetMapping("/{fichaUuid}")
+    public ResponseEntity<ApiReturn<FichaTreinoDTO>> detalhar(@PathVariable UUID fichaUuid) {
+        return ResponseEntity.ok(ApiReturn.of(service.findByUuid(fichaUuid)));
+    }
+
     @GetMapping("/aluno/{alunoUuid}")
     public ResponseEntity<ApiReturn<List<FichaTreinoDTO>>> listarPorAluno(@PathVariable UUID alunoUuid) {
         return ResponseEntity.ok(ApiReturn.of(service.findByAluno(alunoUuid)));

--- a/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
+++ b/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
@@ -1,11 +1,16 @@
 package com.example.demo.repository;
 
 import com.example.demo.entity.FichaTreino;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface FichaTreinoRepository extends JpaRepository<FichaTreino, UUID> {
     List<FichaTreino> findByAluno_Uuid(UUID alunoUuid);
+
+    @EntityGraph(attributePaths = {"categorias", "categorias.exercicios"})
+    Optional<FichaTreino> findByUuid(UUID uuid);
 }

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -193,6 +193,12 @@ public class FichaTreinoService {
         return repository.findByAluno_Uuid(alunoUuid).stream().map(mapper::toDto).toList();
     }
 
+    public FichaTreinoDTO findByUuid(UUID fichaUuid) {
+        FichaTreino ficha = repository.findByUuid(fichaUuid)
+                .orElseThrow(() -> new ApiException("Ficha de treino não encontrada"));
+        return mapper.toDto(ficha);
+    }
+
     public List<FichaTreinoHistoricoDTO> findHistoricoByAluno(UUID alunoUuid) {
         return historicoRepository.findByAluno_UuidOrderByDataCadastroDesc(alunoUuid)
                 .stream()


### PR DESCRIPTION
## Summary
- add repository query with entity graph to load categories and exercises
- expose service method and controller endpoint to fetch a workout sheet by its UUID

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a08bea0b3c83278217fe57b325941c