### PR TITLE
feat: expose latest training sheet for student

### DIFF
--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -1,6 +1,7 @@
 package com.example.demo.controller;
 
 import com.example.demo.common.response.ApiReturn;
+import com.example.demo.common.security.SecurityUtils;
 import com.example.demo.dto.FichaTreinoDTO;
 import com.example.demo.dto.FichaTreinoHistoricoDTO;
 import com.example.demo.service.FichaTreinoService;
@@ -49,5 +50,12 @@ public class FichaTreinoController {
     @PostMapping("/preset/{presetUuid}/aluno/{alunoUuid}")
     public ResponseEntity<ApiReturn<String>> atribuirPreset(@PathVariable UUID presetUuid, @PathVariable UUID alunoUuid) {
         return ResponseEntity.ok(ApiReturn.of(service.assignPreset(presetUuid, alunoUuid)));
+    }
+
+    @GetMapping("/me")
+    @PreAuthorize("hasRole('ALUNO')")
+    public ResponseEntity<ApiReturn<FichaTreinoDTO>> fichaAlunoLogado() {
+        UUID alunoUuid = SecurityUtils.getUsuarioLogadoDetalhes().getUuid();
+        return ResponseEntity.ok(ApiReturn.of(service.findCurrentByAluno(alunoUuid)));
     }
 }

--- a/src/main/java/com/example/demo/repository/FichaTreinoHistoricoRepository.java
+++ b/src/main/java/com/example/demo/repository/FichaTreinoHistoricoRepository.java
@@ -4,8 +4,10 @@ import com.example.demo.entity.FichaTreinoHistorico;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface FichaTreinoHistoricoRepository extends JpaRepository<FichaTreinoHistorico, UUID> {
     List<FichaTreinoHistorico> findByAluno_UuidOrderByDataCadastroDesc(UUID alunoUuid);
+    Optional<FichaTreinoHistorico> findFirstByAluno_UuidOrderByDataCadastroDesc(UUID alunoUuid);
 }

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -199,4 +199,10 @@ public class FichaTreinoService {
                 .map(h -> mapper.toHistoricoDto(h.getFicha()))
                 .toList();
     }
+
+    public FichaTreinoDTO findCurrentByAluno(UUID alunoUuid) {
+        return historicoRepository.findFirstByAluno_UuidOrderByDataCadastroDesc(alunoUuid)
+                .map(h -> mapper.toDto(h.getFicha()))
+                .orElseThrow(() -> new ApiException("Aluno não possui ficha de treino"));
+    }
 }


### PR DESCRIPTION
## Summary
- add repository and service methods to fetch latest training sheet by student
- expose `/fichas/me` endpoint within existing controller for students to retrieve their current workout plan

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_68a08afc56dc8327bb5632a7e95ba1d3