### PR TITLE
Track current training sheet with flag

### DIFF
--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -63,4 +63,9 @@ public class FichaTreinoController {
         UUID alunoUuid = SecurityUtils.getUsuarioLogadoDetalhes().getUuid();
         return ResponseEntity.ok(ApiReturn.of(service.findCurrentByAluno(alunoUuid)));
     }
+
+    @PutMapping("/ficha-atual/{fichaUuid}")
+    public ResponseEntity<ApiReturn<String>> atualizarFichaAtual(@PathVariable UUID fichaUuid) {
+        return ResponseEntity.ok(ApiReturn.of(service.atualizarFichaAtual(fichaUuid)));
+    }
 }

--- a/src/main/java/com/example/demo/dto/FichaTreinoHistoricoDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoHistoricoDTO.java
@@ -10,6 +10,7 @@ public class FichaTreinoHistoricoDTO {
     private LocalDateTime dataAtualizacao;
     private UUID professorUuid;
     private String professorNome;
+    private boolean atual;
 
     public UUID getUuid() {
         return uuid;
@@ -57,6 +58,14 @@ public class FichaTreinoHistoricoDTO {
 
     public void setProfessorNome(String professorNome) {
         this.professorNome = professorNome;
+    }
+
+    public boolean isAtual() {
+        return atual;
+    }
+
+    public void setAtual(boolean atual) {
+        this.atual = atual;
     }
 }
 

--- a/src/main/java/com/example/demo/entity/FichaTreinoHistorico.java
+++ b/src/main/java/com/example/demo/entity/FichaTreinoHistorico.java
@@ -22,6 +22,9 @@ public class FichaTreinoHistorico {
     @Column(nullable = false)
     private LocalDateTime dataCadastro;
 
+    @Column(nullable = false)
+    private boolean atual;
+
     @PrePersist
     private void prePersist() {
         if (uuid == null) {

--- a/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
+++ b/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
@@ -7,6 +7,7 @@ import com.example.demo.dto.FichaTreinoExercicioDTO;
 import com.example.demo.entity.FichaTreino;
 import com.example.demo.entity.FichaTreinoCategoria;
 import com.example.demo.entity.FichaTreinoExercicio;
+import com.example.demo.entity.FichaTreinoHistorico;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
@@ -57,8 +58,9 @@ public class FichaTreinoMapper {
         return dto;
     }
 
-    public FichaTreinoHistoricoDTO toHistoricoDto(FichaTreino ficha) {
+    public FichaTreinoHistoricoDTO toHistoricoDto(FichaTreinoHistorico historico) {
         FichaTreinoHistoricoDTO dto = new FichaTreinoHistoricoDTO();
+        FichaTreino ficha = historico.getFicha();
         dto.setUuid(ficha.getUuid());
         dto.setNome(ficha.getNome());
         dto.setDataCadastro(ficha.getDataCadastro());
@@ -67,6 +69,7 @@ public class FichaTreinoMapper {
             dto.setProfessorUuid(ficha.getProfessor().getUuid());
             dto.setProfessorNome(ficha.getProfessor().getNome());
         }
+        dto.setAtual(historico.isAtual());
         return dto;
     }
 }

--- a/src/main/java/com/example/demo/repository/FichaTreinoHistoricoRepository.java
+++ b/src/main/java/com/example/demo/repository/FichaTreinoHistoricoRepository.java
@@ -9,5 +9,6 @@ import java.util.UUID;
 
 public interface FichaTreinoHistoricoRepository extends JpaRepository<FichaTreinoHistorico, UUID> {
     List<FichaTreinoHistorico> findByAluno_UuidOrderByDataCadastroDesc(UUID alunoUuid);
-    Optional<FichaTreinoHistorico> findFirstByAluno_UuidOrderByDataCadastroDesc(UUID alunoUuid);
+    Optional<FichaTreinoHistorico> findByAluno_UuidAndAtualTrue(UUID alunoUuid);
+    Optional<FichaTreinoHistorico> findByFicha_Uuid(UUID fichaUuid);
 }


### PR DESCRIPTION
## Summary
- add `atual` boolean to `FichaTreinoHistorico` and DTO
- update service to mark previous sheets as not current and query by flag
- add endpoint to set any training sheet as the current one

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a08e34834c832796a2e2a4914235f9