### PR TITLE
Handle multiple bag fetch for ficha

### DIFF
--- a/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
+++ b/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
@@ -11,6 +11,6 @@ import java.util.UUID;
 public interface FichaTreinoRepository extends JpaRepository<FichaTreino, UUID> {
     List<FichaTreino> findByAluno_Uuid(UUID alunoUuid);
 
-    @EntityGraph(attributePaths = {"categorias", "categorias.exercicios"})
+    @EntityGraph(attributePaths = {"categorias"})
     Optional<FichaTreino> findByUuid(UUID uuid);
 }


### PR DESCRIPTION
## Summary
- avoid multiple bag fetch by loading only categories in FichaTreinoRepository

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0905322b08327a503893adf41942f