### PR TITLE
feat: list professor presets

### DIFF
--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -52,6 +52,12 @@ public class FichaTreinoController {
         return ResponseEntity.ok(ApiReturn.of(service.findHistoricoByAluno(alunoUuid)));
     }
 
+    @GetMapping("/presets")
+    @PreAuthorize("hasRole('PROFESSOR')")
+    public ResponseEntity<ApiReturn<List<FichaTreinoDTO>>> listarPresetsProfessor() {
+        return ResponseEntity.ok(ApiReturn.of(service.findPresetsByProfessor()));
+    }
+
     @PostMapping("/preset/{presetUuid}/aluno/{alunoUuid}")
     public ResponseEntity<ApiReturn<String>> atribuirPreset(@PathVariable UUID presetUuid, @PathVariable UUID alunoUuid) {
         return ResponseEntity.ok(ApiReturn.of(service.assignPreset(presetUuid, alunoUuid)));

--- a/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
+++ b/src/main/java/com/example/demo/repository/FichaTreinoRepository.java
@@ -11,6 +11,9 @@ import java.util.UUID;
 public interface FichaTreinoRepository extends JpaRepository<FichaTreino, UUID> {
     List<FichaTreino> findByAluno_Uuid(UUID alunoUuid);
 
+    @EntityGraph(attributePaths = {"categorias", "categorias.exercicios"})
+    List<FichaTreino> findByProfessor_UuidAndPresetTrue(UUID professorUuid);
+
     @EntityGraph(attributePaths = {"categorias"})
     Optional<FichaTreino> findByUuid(UUID uuid);
 }

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -239,4 +239,13 @@ public class FichaTreinoService {
                 .map(h -> mapper.toDto(h.getFicha()))
                 .orElseThrow(() -> new ApiException("Aluno não possui ficha de treino"));
     }
+
+    public List<FichaTreinoDTO> findPresetsByProfessor() {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
+        if (usuario == null) {
+            throw new ApiException("Usuário não autenticado");
+        }
+        List<FichaTreino> fichas = repository.findByProfessor_UuidAndPresetTrue(usuario.getUuid());
+        return fichas.stream().map(mapper::toDto).toList();
+    }
 }


### PR DESCRIPTION
## Summary
- add repository and service methods to fetch preset fichas for the logged professor
- expose GET /fichas/presets endpoint for professors

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a094c0328883278e741ed1c6d321e8