### PR TITLE
feat: add refresh token endpoint

### DIFF
--- a/src/main/java/com/example/demo/dto/AuthResponse.java
+++ b/src/main/java/com/example/demo/dto/AuthResponse.java
@@ -2,6 +2,7 @@ package com.example.demo.dto;
 
 public class AuthResponse {
     private String token;
+    private String refreshToken;
     private boolean primeiroAcesso;
     private String nome;
     private String email;
@@ -10,8 +11,9 @@ public class AuthResponse {
     public AuthResponse() {
     }
 
-    public AuthResponse(String token, boolean primeiroAcesso, String nome, String email, String perfil) {
+    public AuthResponse(String token, String refreshToken, boolean primeiroAcesso, String nome, String email, String perfil) {
         this.token = token;
+        this.refreshToken = refreshToken;
         this.primeiroAcesso = primeiroAcesso;
         this.nome = nome;
         this.email = email;
@@ -24,6 +26,14 @@ public class AuthResponse {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     public boolean isPrimeiroAcesso() {

--- a/src/main/java/com/example/demo/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/example/demo/dto/RefreshTokenRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.dto;
+
+public class RefreshTokenRequest {
+    private String refreshToken;
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}


### PR DESCRIPTION
## Summary
- add refresh token field to auth response
- generate refresh token on login and create refresh endpoint

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e1f0cd083279c57d89c00b8e228