### PR TITLE
feat: upsert ficha via put

### DIFF
--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -27,9 +27,9 @@ public class FichaTreinoController {
         this.service = service;
     }
 
-    @PostMapping
-    public ResponseEntity<ApiReturn<String>> criar(@Validated @RequestBody FichaTreinoDTO dto) {
-        return ResponseEntity.ok(ApiReturn.of(service.create(dto)));
+    @PutMapping
+    public ResponseEntity<ApiReturn<String>> salvar(@Validated @RequestBody FichaTreinoDTO dto) {
+        return ResponseEntity.ok(ApiReturn.of(service.save(dto)));
     }
 
 //    @GetMapping


### PR DESCRIPTION
## Summary
- allow ficha creation/update via PUT
- switch create service to handle updates when UUID provided

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a09c9818488327a0cc9b777ad3dbe3