### PR TITLE
feat: include student name and timestamp in requests

### DIFF
--- a/src/main/java/com/example/demo/dto/SolicitacaoDTO.java
+++ b/src/main/java/com/example/demo/dto/SolicitacaoDTO.java
@@ -3,6 +3,7 @@ package com.example.demo.dto;
 import com.example.demo.domain.enums.StatusSolicitacao;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
@@ -10,5 +11,7 @@ public class SolicitacaoDTO {
     private UUID uuid;
     private UUID professorUuid;
     private UUID alunoUuid;
+    private String alunoNome;
+    private LocalDateTime dataCadastro;
     private StatusSolicitacao status;
 }

--- a/src/main/java/com/example/demo/entity/Solicitacao.java
+++ b/src/main/java/com/example/demo/entity/Solicitacao.java
@@ -4,6 +4,7 @@ import com.example.demo.domain.enums.StatusSolicitacao;
 import jakarta.persistence.*;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
@@ -26,10 +27,16 @@ public class Solicitacao {
     @Column(nullable = false)
     private StatusSolicitacao status = StatusSolicitacao.PENDENTE;
 
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime dataCadastro;
+
     @PrePersist
-    private void gerarUuid() {
+    private void prePersist() {
         if (uuid == null) {
             uuid = UUID.randomUUID();
+        }
+        if (dataCadastro == null) {
+            dataCadastro = LocalDateTime.now();
         }
     }
 }

--- a/src/main/java/com/example/demo/mapper/SolicitacaoMapper.java
+++ b/src/main/java/com/example/demo/mapper/SolicitacaoMapper.java
@@ -17,6 +17,7 @@ public class SolicitacaoMapper {
         SolicitacaoDTO dto = mapper.map(solicitacao, SolicitacaoDTO.class);
         dto.setProfessorUuid(solicitacao.getProfessor().getUuid());
         dto.setAlunoUuid(solicitacao.getAluno().getUuid());
+        dto.setAlunoNome(solicitacao.getAluno().getNome());
         return dto;
     }
 }


### PR DESCRIPTION
## Summary
- add creation timestamp to `Solicitacao` entity
- expose student name and request date in `SolicitacaoDTO`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch Maven distribution)*
- `mvn -q test` *(fails: Could not transfer artifacts - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bf89e6488327ba44906288c2658d