### PR TITLE
Include exercise name in training sheet details

### DIFF
--- a/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 public class FichaTreinoExercicioDTO {
     private UUID exercicioUuid;
+    private String exercicioNome;
     private Integer repeticoes;
     private Double carga;
 
@@ -13,6 +14,14 @@ public class FichaTreinoExercicioDTO {
 
     public void setExercicioUuid(UUID exercicioUuid) {
         this.exercicioUuid = exercicioUuid;
+    }
+
+    public String getExercicioNome() {
+        return exercicioNome;
+    }
+
+    public void setExercicioNome(String exercicioNome) {
+        this.exercicioNome = exercicioNome;
     }
 
     public Integer getRepeticoes() {

--- a/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
+++ b/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
@@ -53,6 +53,7 @@ public class FichaTreinoMapper {
     private FichaTreinoExercicioDTO toExercicioDto(FichaTreinoExercicio exercicio) {
         FichaTreinoExercicioDTO dto = new FichaTreinoExercicioDTO();
         dto.setExercicioUuid(exercicio.getExercicio().getUuid());
+        dto.setExercicioNome(exercicio.getExercicio().getNome());
         dto.setRepeticoes(exercicio.getRepeticoes());
         dto.setCarga(exercicio.getCarga());
         return dto;


### PR DESCRIPTION
## Summary
- Add `exercicioNome` to training exercise DTO
- Map exercise name when converting ficha to DTO

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c41d16d08327a9a8398243c6f8f6