### PR TITLE
feat: add notification system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,10 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
         </dependency>

--- a/src/main/java/com/example/demo/config/WebSocketConfig.java
+++ b/src/main/java/com/example/demo/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOrigins("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/example/demo/controller/NotificacaoController.java
+++ b/src/main/java/com/example/demo/controller/NotificacaoController.java
@@ -1,0 +1,36 @@
+package com.example.demo.controller;
+
+import com.example.demo.common.response.ApiReturn;
+import com.example.demo.dto.NotificacaoDTO;
+import com.example.demo.service.NotificacaoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Notificações")
+@RestController
+@RequestMapping("/notificacoes")
+public class NotificacaoController {
+    private final NotificacaoService service;
+
+    public NotificacaoController(NotificacaoService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiReturn<List<NotificacaoDTO>>> listar() {
+        return ResponseEntity.ok(ApiReturn.of(service.listarDoUsuarioLogado()));
+    }
+
+    @PostMapping("/{uuid}/lida")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiReturn<String>> marcarComoLida(@PathVariable UUID uuid) {
+        service.marcarComoLida(uuid);
+        return ResponseEntity.ok(ApiReturn.of("Notificação marcada como lida"));
+    }
+}

--- a/src/main/java/com/example/demo/domain/enums/TipoNotificacao.java
+++ b/src/main/java/com/example/demo/domain/enums/TipoNotificacao.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.enums;
+
+public enum TipoNotificacao {
+    EMAIL,
+    PUSH
+}

--- a/src/main/java/com/example/demo/dto/NotificacaoDTO.java
+++ b/src/main/java/com/example/demo/dto/NotificacaoDTO.java
@@ -1,0 +1,54 @@
+package com.example.demo.dto;
+
+import com.example.demo.domain.enums.TipoNotificacao;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class NotificacaoDTO {
+    private UUID uuid;
+    private String mensagem;
+    private TipoNotificacao tipo;
+    private boolean lida;
+    private LocalDateTime dataCriacao;
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public void setMensagem(String mensagem) {
+        this.mensagem = mensagem;
+    }
+
+    public TipoNotificacao getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(TipoNotificacao tipo) {
+        this.tipo = tipo;
+    }
+
+    public boolean isLida() {
+        return lida;
+    }
+
+    public void setLida(boolean lida) {
+        this.lida = lida;
+    }
+
+    public LocalDateTime getDataCriacao() {
+        return dataCriacao;
+    }
+
+    public void setDataCriacao(LocalDateTime dataCriacao) {
+        this.dataCriacao = dataCriacao;
+    }
+}

--- a/src/main/java/com/example/demo/entity/Notificacao.java
+++ b/src/main/java/com/example/demo/entity/Notificacao.java
@@ -1,0 +1,43 @@
+package com.example.demo.entity;
+
+import com.example.demo.domain.enums.TipoNotificacao;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Entity
+public class Notificacao {
+    @Id
+    @Column(nullable = false, updatable = false, unique = true)
+    private UUID uuid;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "destinatario_uuid")
+    private Usuario destinatario;
+
+    @Column(nullable = false)
+    private String mensagem;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TipoNotificacao tipo;
+
+    @Column(nullable = false)
+    private boolean lida = false;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime dataCriacao;
+
+    @PrePersist
+    private void prePersist() {
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+        if (dataCriacao == null) {
+            dataCriacao = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/mapper/NotificacaoMapper.java
+++ b/src/main/java/com/example/demo/mapper/NotificacaoMapper.java
@@ -1,0 +1,19 @@
+package com.example.demo.mapper;
+
+import com.example.demo.dto.NotificacaoDTO;
+import com.example.demo.entity.Notificacao;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificacaoMapper {
+    private final ModelMapper mapper;
+
+    public NotificacaoMapper(ModelMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public NotificacaoDTO toDto(Notificacao notificacao) {
+        return mapper.map(notificacao, NotificacaoDTO.class);
+    }
+}

--- a/src/main/java/com/example/demo/repository/NotificacaoRepository.java
+++ b/src/main/java/com/example/demo/repository/NotificacaoRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Notificacao;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificacaoRepository extends JpaRepository<Notificacao, UUID> {
+    List<Notificacao> findByDestinatarioUuidOrderByDataCriacaoDesc(UUID uuid);
+}

--- a/src/main/java/com/example/demo/service/EmailService.java
+++ b/src/main/java/com/example/demo/service/EmailService.java
@@ -31,4 +31,16 @@ public class EmailService {
         message.setText(texto.toString());
         mailSender.send(message);
     }
+
+    public void enviarNotificacao(String destinatario, String assunto, String texto) {
+        if (destinatario == null || destinatario.isBlank()) {
+            return;
+        }
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(mailProperties.getFrom());
+        message.setTo(destinatario);
+        message.setSubject(assunto);
+        message.setText(texto);
+        mailSender.send(message);
+    }
 }

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -32,8 +32,16 @@ public class FichaTreinoService {
     private final UsuarioRepository usuarioRepository;
     private final ExercicioRepository exercicioRepository;
     private final FichaTreinoHistoricoRepository historicoRepository;
+    private final NotificacaoService notificacaoService;
 
-    public FichaTreinoService(FichaTreinoRepository repository, FichaTreinoMapper mapper, AlunoRepository alunoRepository, ProfessorRepository professorRepository, UsuarioRepository usuarioRepository, ExercicioRepository exercicioRepository, FichaTreinoHistoricoRepository historicoRepository) {
+    public FichaTreinoService(FichaTreinoRepository repository,
+                              FichaTreinoMapper mapper,
+                              AlunoRepository alunoRepository,
+                              ProfessorRepository professorRepository,
+                              UsuarioRepository usuarioRepository,
+                              ExercicioRepository exercicioRepository,
+                              FichaTreinoHistoricoRepository historicoRepository,
+                              NotificacaoService notificacaoService) {
         this.repository = repository;
         this.mapper = mapper;
         this.alunoRepository = alunoRepository;
@@ -41,6 +49,7 @@ public class FichaTreinoService {
         this.usuarioRepository = usuarioRepository;
         this.exercicioRepository = exercicioRepository;
         this.historicoRepository = historicoRepository;
+        this.notificacaoService = notificacaoService;
     }
 
     @Transactional
@@ -69,10 +78,15 @@ public class FichaTreinoService {
         ficha.setCategorias(montarCategorias(dto, ficha));
 
         repository.save(ficha);
-
         if (isNew) {
             salvarHistoricoSeNecessario(ficha);
+            if (aluno != null) {
+                notificacaoService.notificarNovaFichaTreino(aluno);
+            }
             return "Ficha de treino criada com sucesso";
+        }
+        if (aluno != null) {
+            notificacaoService.notificarNovaFichaTreino(aluno);
         }
         return "Ficha de treino atualizada com sucesso";
     }
@@ -218,6 +232,7 @@ public class FichaTreinoService {
         historico.setFicha(ficha);
         historico.setAtual(true);
         historicoRepository.save(historico);
+        notificacaoService.notificarNovaFichaTreino(aluno);
         return "Ficha atribuída ao aluno";
     }
 

--- a/src/main/java/com/example/demo/service/NotificacaoService.java
+++ b/src/main/java/com/example/demo/service/NotificacaoService.java
@@ -1,0 +1,92 @@
+package com.example.demo.service;
+
+import com.example.demo.common.security.SecurityUtils;
+import com.example.demo.common.security.UsuarioLogado;
+import com.example.demo.domain.enums.TipoNotificacao;
+import com.example.demo.dto.NotificacaoDTO;
+import com.example.demo.entity.Aluno;
+import com.example.demo.entity.Notificacao;
+import com.example.demo.entity.Usuario;
+import com.example.demo.exception.ApiException;
+import com.example.demo.mapper.NotificacaoMapper;
+import com.example.demo.repository.AlunoRepository;
+import com.example.demo.repository.NotificacaoRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class NotificacaoService {
+    private final NotificacaoRepository repository;
+    private final EmailService emailService;
+    private final NotificacaoMapper mapper;
+    private final AlunoRepository alunoRepository;
+
+    public NotificacaoService(NotificacaoRepository repository,
+                              EmailService emailService,
+                              NotificacaoMapper mapper,
+                              AlunoRepository alunoRepository) {
+        this.repository = repository;
+        this.emailService = emailService;
+        this.mapper = mapper;
+        this.alunoRepository = alunoRepository;
+    }
+
+    public void criar(Usuario destinatario, String mensagem, TipoNotificacao tipo) {
+        Notificacao n = new Notificacao();
+        n.setDestinatario(destinatario);
+        n.setMensagem(mensagem);
+        n.setTipo(tipo);
+        repository.save(n);
+        dispatch(n);
+    }
+
+    private void dispatch(Notificacao notificacao) {
+        if (notificacao.getTipo() == TipoNotificacao.EMAIL) {
+            emailService.enviarNotificacao(notificacao.getDestinatario().getEmail(),
+                    "Notificação", notificacao.getMensagem());
+        } else if (notificacao.getTipo() == TipoNotificacao.PUSH) {
+            // TODO: integrar com serviço de push notification
+            System.out.println("Push: " + notificacao.getMensagem());
+        }
+    }
+
+    public List<NotificacaoDTO> listarDoUsuarioLogado() {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
+        if (usuario == null) {
+            return List.of();
+        }
+        return repository.findByDestinatarioUuidOrderByDataCriacaoDesc(usuario.getUuid())
+                .stream().map(mapper::toDto).toList();
+    }
+
+    public void marcarComoLida(UUID uuid) {
+        Notificacao n = repository.findById(uuid).orElseThrow(() -> new ApiException("Notificação não encontrada"));
+        n.setLida(true);
+        repository.save(n);
+    }
+
+    @Scheduled(cron = "0 0 6 * * *")
+    public void verificarExpiracaoMatriculas() {
+        LocalDate hoje = LocalDate.now();
+        for (Aluno aluno : alunoRepository.findAll()) {
+            if (aluno.getDataMatricula() != null) {
+                LocalDate expiracao = aluno.getDataMatricula().plusYears(1);
+                if (expiracao.minusDays(7).isEqual(hoje)) {
+                    criar(aluno, "Sua matrícula expira em 7 dias", TipoNotificacao.EMAIL);
+                } else if (expiracao.isEqual(hoje)) {
+                    criar(aluno, "Sua matrícula expirou", TipoNotificacao.EMAIL);
+                }
+            }
+        }
+    }
+
+    public void notificarNovaFichaTreino(Aluno aluno) {
+        if (aluno != null) {
+            criar(aluno, "Uma nova ficha de treino foi atribuída", TipoNotificacao.PUSH);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Notificacao entity and repository
- implement NotificacaoService with email/push dispatch and scheduled checks
- expose endpoints to list notifications and mark as read
- trigger notifications when training plans are created
- add WebSocket config and dependency for future push updates

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c35ba7d88327b1c89076276516dd