### PR TITLE
Add rest and series tracking to exercises with sheet validity and category notes

### DIFF
--- a/src/main/java/com/example/demo/dto/FichaTreinoCategoriaDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoCategoriaDTO.java
@@ -7,6 +7,7 @@ public class FichaTreinoCategoriaDTO {
     private UUID uuid;
     private String nome;
     private List<FichaTreinoExercicioDTO> exercicios;
+    private String observacao;
 
     public UUID getUuid() {
         return uuid;
@@ -30,5 +31,13 @@ public class FichaTreinoCategoriaDTO {
 
     public void setExercicios(List<FichaTreinoExercicioDTO> exercicios) {
         this.exercicios = exercicios;
+    }
+
+    public String getObservacao() {
+        return observacao;
+    }
+
+    public void setObservacao(String observacao) {
+        this.observacao = observacao;
     }
 }

--- a/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoDTO.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -11,6 +12,7 @@ public class FichaTreinoDTO {
     private String nome;
     private boolean preset;
     private List<FichaTreinoCategoriaDTO> categorias;
+    private LocalDate dataValidade;
     private LocalDateTime dataCadastro;
     private LocalDateTime dataAtualizacao;
 
@@ -60,6 +62,14 @@ public class FichaTreinoDTO {
 
     public void setCategorias(List<FichaTreinoCategoriaDTO> categorias) {
         this.categorias = categorias;
+    }
+
+    public LocalDate getDataValidade() {
+        return dataValidade;
+    }
+
+    public void setDataValidade(LocalDate dataValidade) {
+        this.dataValidade = dataValidade;
     }
 
     public LocalDateTime getDataCadastro() {

--- a/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
@@ -6,6 +6,8 @@ public class FichaTreinoExercicioDTO {
     private UUID exercicioUuid;
     private Integer repeticoes;
     private Double carga;
+    private Integer series;
+    private Integer tempoDescanso;
 
     public UUID getExercicioUuid() {
         return exercicioUuid;
@@ -29,5 +31,21 @@ public class FichaTreinoExercicioDTO {
 
     public void setCarga(Double carga) {
         this.carga = carga;
+    }
+
+    public Integer getSeries() {
+        return series;
+    }
+
+    public void setSeries(Integer series) {
+        this.series = series;
+    }
+
+    public Integer getTempoDescanso() {
+        return tempoDescanso;
+    }
+
+    public void setTempoDescanso(Integer tempoDescanso) {
+        this.tempoDescanso = tempoDescanso;
     }
 }

--- a/src/main/java/com/example/demo/entity/FichaTreino.java
+++ b/src/main/java/com/example/demo/entity/FichaTreino.java
@@ -3,6 +3,7 @@ package com.example.demo.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +27,9 @@ public class FichaTreino {
 
     @Column(nullable = false)
     private boolean preset;
+
+    @Column
+    private LocalDate dataValidade;
 
     @OneToMany(mappedBy = "ficha", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FichaTreinoCategoria> categorias = new ArrayList<>();

--- a/src/main/java/com/example/demo/entity/FichaTreinoCategoria.java
+++ b/src/main/java/com/example/demo/entity/FichaTreinoCategoria.java
@@ -22,6 +22,9 @@ public class FichaTreinoCategoria {
     @Column(nullable = false)
     private String nome;
 
+    @Column
+    private String observacao;
+
     @OneToMany(mappedBy = "categoria", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FichaTreinoExercicio> exercicios = new ArrayList<>();
 

--- a/src/main/java/com/example/demo/entity/FichaTreinoExercicio.java
+++ b/src/main/java/com/example/demo/entity/FichaTreinoExercicio.java
@@ -27,6 +27,12 @@ public class FichaTreinoExercicio {
     @Column(nullable = false)
     private Double carga;
 
+    @Column(nullable = false)
+    private Integer series;
+
+    @Column(nullable = false)
+    private Integer tempoDescanso;
+
     @PrePersist
     private void gerarUuid() {
         if (uuid == null) {

--- a/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
+++ b/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
@@ -32,6 +32,7 @@ public class FichaTreinoMapper {
         }
         dto.setNome(ficha.getNome());
         dto.setPreset(ficha.isPreset());
+        dto.setDataValidade(ficha.getDataValidade());
         dto.setDataCadastro(ficha.getDataCadastro());
         dto.setDataAtualizacao(ficha.getDataAtualizacao());
         dto.setCategorias(ficha.getCategorias().stream().map(this::toCategoriaDto).collect(Collectors.toList()));
@@ -46,6 +47,7 @@ public class FichaTreinoMapper {
         FichaTreinoCategoriaDTO dto = new FichaTreinoCategoriaDTO();
         dto.setUuid(categoria.getUuid());
         dto.setNome(categoria.getNome());
+        dto.setObservacao(categoria.getObservacao());
         dto.setExercicios(categoria.getExercicios().stream().map(this::toExercicioDto).collect(Collectors.toList()));
         return dto;
     }
@@ -55,6 +57,8 @@ public class FichaTreinoMapper {
         dto.setExercicioUuid(exercicio.getExercicio().getUuid());
         dto.setRepeticoes(exercicio.getRepeticoes());
         dto.setCarga(exercicio.getCarga());
+        dto.setSeries(exercicio.getSeries());
+        dto.setTempoDescanso(exercicio.getTempoDescanso());
         return dto;
     }
 

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -63,6 +63,7 @@ public class FichaTreinoService {
             ficha.setPreset(dto.isPreset());
             ficha.setAluno(aluno);
             ficha.setProfessor(professor);
+            ficha.setDataValidade(dto.getDataValidade());
             ficha.getCategorias().clear();
         }
 
@@ -133,6 +134,7 @@ public class FichaTreinoService {
         FichaTreino ficha = new FichaTreino();
         ficha.setNome(dto.getNome());
         ficha.setPreset(dto.isPreset());
+        ficha.setDataValidade(dto.getDataValidade());
         ficha.setAluno(aluno);
         ficha.setProfessor(professor);
         return ficha;
@@ -143,6 +145,7 @@ public class FichaTreinoService {
         return dto.getCategorias().stream().map(cDto -> {
             FichaTreinoCategoria categoria = new FichaTreinoCategoria();
             categoria.setNome(cDto.getNome());
+            categoria.setObservacao(cDto.getObservacao());
             categoria.setFicha(ficha);
             categoria.setExercicios(montarExercicios(cDto, categoria));
             return categoria;
@@ -157,6 +160,8 @@ public class FichaTreinoService {
             fe.setExercicio(exercicio);
             fe.setRepeticoes(eDto.getRepeticoes());
             fe.setCarga(eDto.getCarga());
+            fe.setSeries(eDto.getSeries());
+            fe.setTempoDescanso(eDto.getTempoDescanso());
             fe.setCategoria(categoria);
             return fe;
         }).toList();
@@ -190,10 +195,12 @@ public class FichaTreinoService {
         ficha.setAluno(aluno);
         ficha.setProfessor(preset.getProfessor());
         ficha.setPreset(false);
+        ficha.setDataValidade(preset.getDataValidade());
         ficha.setCategorias(new java.util.ArrayList<>());
         for (FichaTreinoCategoria categoria : preset.getCategorias()) {
             FichaTreinoCategoria novaCat = new FichaTreinoCategoria();
             novaCat.setNome(categoria.getNome());
+            novaCat.setObservacao(categoria.getObservacao());
             novaCat.setFicha(ficha);
             novaCat.setExercicios(new java.util.ArrayList<>());
             for (FichaTreinoExercicio exercicio : categoria.getExercicios()) {
@@ -201,6 +208,8 @@ public class FichaTreinoService {
                 novo.setExercicio(exercicio.getExercicio());
                 novo.setRepeticoes(exercicio.getRepeticoes());
                 novo.setCarga(exercicio.getCarga());
+                novo.setSeries(exercicio.getSeries());
+                novo.setTempoDescanso(exercicio.getTempoDescanso());
                 novo.setCategoria(novaCat);
                 novaCat.getExercicios().add(novo);
             }


### PR DESCRIPTION
## Summary
- add optional dataValidade to training sheets
- track exercise rest time and number of series
- allow category-level observacao notes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c52c74e48327b0b197546699ab87