### PR TITLE
Add academy code and public student self-signup

### DIFF
--- a/src/main/java/com/example/demo/controller/AcademiaPublicController.java
+++ b/src/main/java/com/example/demo/controller/AcademiaPublicController.java
@@ -1,0 +1,27 @@
+package com.example.demo.controller;
+
+import com.example.demo.common.response.ApiReturn;
+import com.example.demo.dto.AcademiaDTO;
+import com.example.demo.service.AcademiaService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Academias - Público")
+@RestController
+@RequestMapping("/api/public/academias")
+public class AcademiaPublicController {
+    private final AcademiaService service;
+
+    public AcademiaPublicController(AcademiaService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/{codigo}")
+    public ResponseEntity<ApiReturn<AcademiaDTO>> buscarPorCodigo(@PathVariable String codigo) {
+        return ResponseEntity.ok(ApiReturn.of(service.findByCodigo(codigo)));
+    }
+}

--- a/src/main/java/com/example/demo/controller/AlunoPublicController.java
+++ b/src/main/java/com/example/demo/controller/AlunoPublicController.java
@@ -1,0 +1,28 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.AlunoDTO;
+import com.example.demo.common.response.ApiReturn;
+import com.example.demo.service.AlunoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Alunos - Público")
+@RestController
+@RequestMapping("/api/public/alunos")
+public class AlunoPublicController {
+    private final AlunoService service;
+
+    public AlunoPublicController(AlunoService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiReturn<String>> criar(@Validated @RequestBody AlunoDTO dto) {
+        return ResponseEntity.ok(ApiReturn.of(service.create(dto)));
+    }
+}

--- a/src/main/java/com/example/demo/dto/AcademiaDTO.java
+++ b/src/main/java/com/example/demo/dto/AcademiaDTO.java
@@ -12,6 +12,7 @@ public class AcademiaDTO {
     private String logradouro;
     private String bairro;
     private String telefone;
+    private String codigo;
     private UsuarioDTO admin;
 
     public UUID getUuid() {
@@ -84,6 +85,14 @@ public class AcademiaDTO {
 
     public void setTelefone(String telefone) {
         this.telefone = telefone;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
     }
 
     public UsuarioDTO getAdmin() {

--- a/src/main/java/com/example/demo/dto/AlunoDTO.java
+++ b/src/main/java/com/example/demo/dto/AlunoDTO.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 public class AlunoDTO extends UsuarioDTO {
     private LocalDate dataMatricula;
     private UUID professorUuid;
+    private String codigoAcademia;
 
     public LocalDate getDataMatricula() {
         return dataMatricula;
@@ -21,5 +22,13 @@ public class AlunoDTO extends UsuarioDTO {
 
     public void setProfessorUuid(UUID professorUuid) {
         this.professorUuid = professorUuid;
+    }
+
+    public String getCodigoAcademia() {
+        return codigoAcademia;
+    }
+
+    public void setCodigoAcademia(String codigoAcademia) {
+        this.codigoAcademia = codigoAcademia;
     }
 }

--- a/src/main/java/com/example/demo/entity/Academia.java
+++ b/src/main/java/com/example/demo/entity/Academia.java
@@ -15,6 +15,9 @@ public class Academia {
     @Column(nullable = false)
     private String nome;
 
+    @Column(nullable = false, unique = true)
+    private String codigo;
+
     private String uf;
     private String cidade;
     private String cep;
@@ -29,6 +32,10 @@ public class Academia {
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "admin_uuid", referencedColumnName = "uuid", nullable = false)
     private Usuario admin;
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo != null ? codigo.toUpperCase() : null;
+    }
 
     @PrePersist
     private void gerarUuid() {

--- a/src/main/java/com/example/demo/repository/AcademiaRepository.java
+++ b/src/main/java/com/example/demo/repository/AcademiaRepository.java
@@ -14,4 +14,6 @@ public interface AcademiaRepository extends JpaRepository<Academia, UUID> {
     Academia findByUuid(UUID uuid);
 
     Page<Academia> findByNomeContainingIgnoreCase(String nome, Pageable pageable);
+
+    Optional<Academia> findByCodigo(String codigo);
 }

--- a/src/main/java/com/example/demo/service/AcademiaService.java
+++ b/src/main/java/com/example/demo/service/AcademiaService.java
@@ -88,6 +88,12 @@ public class AcademiaService {
         return mapper.toDto(entity);
     }
 
+    public AcademiaDTO findByCodigo(String codigo) {
+        Academia entity = repository.findByCodigo(codigo.toUpperCase())
+                .orElseThrow(() -> new ApiException("Academia não encontrada"));
+        return mapper.toDto(entity);
+    }
+
     @Transactional
     public String update(UUID uuid, AcademiaDTO dto) {
         Academia entity = repository.findById(uuid).orElseThrow(() -> new ApiException("Academia não encontrada"));
@@ -99,6 +105,7 @@ public class AcademiaService {
         entity.setLogradouro(dto.getLogradouro());
         entity.setBairro(dto.getBairro());
         entity.setTelefone(dto.getTelefone());
+        entity.setCodigo(dto.getCodigo());
 
         if (dto.getAdmin() != null && entity.getAdmin() != null) {
             entity.getAdmin().setNome(dto.getAdmin().getNome());

--- a/src/main/java/com/example/demo/service/AlunoService.java
+++ b/src/main/java/com/example/demo/service/AlunoService.java
@@ -70,12 +70,17 @@ public class AlunoService {
         UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
         boolean isMaster = usuario != null && usuario.possuiPerfil(Perfil.MASTER);
         if (usuario != null && !isMaster) {
-
             Academia academia = academiaRepository.findByUuid(usuario.getAcademiaUuid());
             if (academia == null) {
                 throw new ApiException("Usuário precisa ter uma academia associada");
             }
-
+            entity.setAcademia(academia);
+        } else {
+            if (dto.getCodigoAcademia() == null || dto.getCodigoAcademia().isBlank()) {
+                throw new ApiException("Código da academia é obrigatório");
+            }
+            Academia academia = academiaRepository.findByCodigo(dto.getCodigoAcademia().toUpperCase())
+                    .orElseThrow(() -> new ApiException("Academia não encontrada"));
             entity.setAcademia(academia);
         }
         repository.save(entity);


### PR DESCRIPTION
## Summary
- add unique uppercased code field to Academia and expose on DTO
- allow students to self-register via public endpoint using academy code
- add public endpoint to fetch academy details by code

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d054d9a883278f63df28d7a6d2ff