### PR TITLE
Track treino progresso e próxima categoria

### DIFF
--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -111,9 +111,16 @@ public class AlunoController {
 
     @PostMapping("/registrar-treino")
     @PreAuthorize("hasRole('ALUNO')")
-    public ResponseEntity<ApiReturn<String>> registrarTreino(@Validated @RequestBody TreinoSessaoDTO dto) {
+    public ResponseEntity<ApiReturn<Double>> registrarTreino(@Validated @RequestBody TreinoSessaoDTO dto) {
         UUID uuid = SecurityUtils.getUsuarioLogadoDetalhes().getUuid();
         return ResponseEntity.ok(ApiReturn.of(treinoSessaoService.registrarSessao(uuid, dto)));
+    }
+
+    @GetMapping("/me/treinos/percentual/{categoriaUuid}")
+    @PreAuthorize("hasRole('ALUNO')")
+    public ResponseEntity<ApiReturn<Double>> percentualTreino(@PathVariable UUID categoriaUuid) {
+        UUID uuid = SecurityUtils.getUsuarioLogadoDetalhes().getUuid();
+        return ResponseEntity.ok(ApiReturn.of(treinoSessaoService.buscarPercentualDoDia(uuid, categoriaUuid)));
     }
 
     @GetMapping("/{uuid}/treinos")

--- a/src/main/java/com/example/demo/dto/FichaTreinoCategoriaDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoCategoriaDTO.java
@@ -8,6 +8,8 @@ public class FichaTreinoCategoriaDTO {
     private String nome;
     private List<FichaTreinoExercicioDTO> exercicios;
     private String observacao;
+    private double percentualConcluido;
+    private boolean ativo;
 
     public UUID getUuid() {
         return uuid;
@@ -39,5 +41,21 @@ public class FichaTreinoCategoriaDTO {
 
     public void setObservacao(String observacao) {
         this.observacao = observacao;
+    }
+
+    public double getPercentualConcluido() {
+        return percentualConcluido;
+    }
+
+    public void setPercentualConcluido(double percentualConcluido) {
+        this.percentualConcluido = percentualConcluido;
+    }
+
+    public boolean isAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(boolean ativo) {
+        this.ativo = ativo;
     }
 }

--- a/src/main/java/com/example/demo/entity/TreinoDesempenho.java
+++ b/src/main/java/com/example/demo/entity/TreinoDesempenho.java
@@ -1,0 +1,34 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@Entity
+public class TreinoDesempenho {
+    @Id
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID uuid;
+
+    @ManyToOne(optional = false)
+    private Aluno aluno;
+
+    @ManyToOne(optional = false)
+    private FichaTreinoCategoria categoria;
+
+    @Column(nullable = false)
+    private LocalDate data;
+
+    @Column(nullable = false)
+    private double percentual;
+
+    @PrePersist
+    private void prePersist() {
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/repository/TreinoDesempenhoRepository.java
+++ b/src/main/java/com/example/demo/repository/TreinoDesempenhoRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.TreinoDesempenho;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TreinoDesempenhoRepository extends JpaRepository<TreinoDesempenho, UUID> {
+    Optional<TreinoDesempenho> findByAluno_UuidAndCategoria_UuidAndData(UUID alunoUuid, UUID categoriaUuid, LocalDate data);
+}

--- a/src/main/java/com/example/demo/repository/TreinoSessaoRepository.java
+++ b/src/main/java/com/example/demo/repository/TreinoSessaoRepository.java
@@ -3,9 +3,14 @@ package com.example.demo.repository;
 import com.example.demo.entity.TreinoSessao;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public interface TreinoSessaoRepository extends JpaRepository<TreinoSessao, UUID> {
     List<TreinoSessao> findByAlunoUuid(UUID alunoUuid);
+
+    long countByAlunoUuidAndExercicio_Categoria_UuidAndData(UUID alunoUuid, UUID categoriaUuid, LocalDate data);
+
+    List<TreinoSessao> findByAlunoUuidAndDataBeforeOrderByDataDesc(UUID alunoUuid, LocalDate data);
 }


### PR DESCRIPTION
## Summary
- Adiciona campos de progresso e sinalização de treino do dia nas categorias da ficha
- Salva desempenho diário ao registrar sessão de treino
- Determina próxima categoria com base no histórico e expõe percentual concluído
- Disponibiliza endpoint para consultar apenas o percentual diário de uma categoria

## Testing
- `./mvnw -q test` *(falha: Failed to fetch https://repo.maven.apache.org/...)*
- `mvn -q test` *(falha: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a25472760083279eec4f4ff463d59c