### PR TITLE
Add status tracking for workout sessions

### DIFF
--- a/src/main/java/com/example/demo/domain/enums/StatusTreino.java
+++ b/src/main/java/com/example/demo/domain/enums/StatusTreino.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.enums;
+
+public enum StatusTreino {
+    PENDENTE,
+    EM_ANDAMENTO,
+    CONCLUIDO
+}

--- a/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
+++ b/src/main/java/com/example/demo/dto/FichaTreinoExercicioDTO.java
@@ -1,9 +1,11 @@
 package com.example.demo.dto;
 
 import com.example.demo.entity.Musculo;
+import com.example.demo.domain.enums.StatusTreino;
 import java.util.UUID;
 
 public class FichaTreinoExercicioDTO {
+    private UUID uuid;
     private UUID exercicioUuid;
     private String exercicioNome;
     private Musculo musculo;
@@ -11,6 +13,15 @@ public class FichaTreinoExercicioDTO {
     private Double carga;
     private Integer series;
     private Integer tempoDescanso;
+    private StatusTreino status;
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
 
     public UUID getExercicioUuid() {
         return exercicioUuid;
@@ -66,5 +77,13 @@ public class FichaTreinoExercicioDTO {
 
     public void setTempoDescanso(Integer tempoDescanso) {
         this.tempoDescanso = tempoDescanso;
+    }
+
+    public StatusTreino getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusTreino status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/demo/dto/TreinoSessaoDTO.java
+++ b/src/main/java/com/example/demo/dto/TreinoSessaoDTO.java
@@ -3,11 +3,14 @@ package com.example.demo.dto;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import com.example.demo.domain.enums.StatusTreino;
+
 public class TreinoSessaoDTO {
     private UUID exercicioUuid;
     private LocalDate data;
     private Integer repeticoesRealizadas;
     private Double cargaRealizada;
+    private StatusTreino status;
 
     public UUID getExercicioUuid() {
         return exercicioUuid;
@@ -39,5 +42,13 @@ public class TreinoSessaoDTO {
 
     public void setCargaRealizada(Double cargaRealizada) {
         this.cargaRealizada = cargaRealizada;
+    }
+
+    public StatusTreino getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusTreino status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/demo/entity/TreinoSessao.java
+++ b/src/main/java/com/example/demo/entity/TreinoSessao.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import com.example.demo.domain.enums.StatusTreino;
+
 @Data
 @Entity
 public class TreinoSessao {
@@ -22,16 +24,23 @@ public class TreinoSessao {
     @Column(nullable = false)
     private LocalDate data;
 
-    @Column(nullable = false)
+    @Column
     private Integer repeticoesRealizadas;
 
-    @Column(nullable = false)
+    @Column
     private Double cargaRealizada;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatusTreino status;
 
     @PrePersist
     private void prePersist() {
         if (uuid == null) {
             uuid = UUID.randomUUID();
+        }
+        if (status == null) {
+            status = StatusTreino.EM_ANDAMENTO;
         }
     }
 }

--- a/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
+++ b/src/main/java/com/example/demo/mapper/FichaTreinoMapper.java
@@ -54,6 +54,7 @@ public class FichaTreinoMapper {
 
     private FichaTreinoExercicioDTO toExercicioDto(FichaTreinoExercicio exercicio) {
         FichaTreinoExercicioDTO dto = new FichaTreinoExercicioDTO();
+        dto.setUuid(exercicio.getUuid());
         dto.setExercicioUuid(exercicio.getExercicio().getUuid());
         dto.setExercicioNome(exercicio.getExercicio().getNome());
         dto.setMusculo(exercicio.getExercicio().getMusculo());

--- a/src/main/java/com/example/demo/repository/TreinoSessaoRepository.java
+++ b/src/main/java/com/example/demo/repository/TreinoSessaoRepository.java
@@ -1,16 +1,22 @@
 package com.example.demo.repository;
 
 import com.example.demo.entity.TreinoSessao;
+import com.example.demo.domain.enums.StatusTreino;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface TreinoSessaoRepository extends JpaRepository<TreinoSessao, UUID> {
     List<TreinoSessao> findByAlunoUuid(UUID alunoUuid);
 
-    long countByAlunoUuidAndExercicio_Categoria_UuidAndData(UUID alunoUuid, UUID categoriaUuid, LocalDate data);
+    Optional<TreinoSessao> findByAlunoUuidAndExercicio_UuidAndData(UUID alunoUuid, UUID exercicioUuid, LocalDate data);
+
+    long countByAlunoUuidAndExercicio_Categoria_UuidAndDataAndStatus(UUID alunoUuid, UUID categoriaUuid, LocalDate data, StatusTreino status);
+
+    List<TreinoSessao> findByAlunoUuidAndData(UUID alunoUuid, LocalDate data);
 
     List<TreinoSessao> findByAlunoUuidAndDataBeforeOrderByDataDesc(UUID alunoUuid, LocalDate data);
 }


### PR DESCRIPTION
## Summary
- track training session status with enum `StatusTreino`
- update session registration to toggle between *EM_ANDAMENTO* and *CONCLUIDO*
- expose exercise status in current workout sheet

## Testing
- `mvn test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2680df9a483279c981121026eb9fc