### PR TITLE
feat: add measurement history and user cap

### DIFF
--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -87,8 +87,8 @@ public class AlunoController {
 
     @PostMapping("/{uuid}/medidas")
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR')")
-    public ResponseEntity<ApiReturn<String>> adicionarMedida(@PathVariable UUID uuid,
-                                                             @Validated @RequestBody AlunoMedidaDTO dto) {
+    public ResponseEntity<ApiReturn<AlunoMedidaResultadoDTO>> adicionarMedida(@PathVariable UUID uuid,
+                                                                              @Validated @RequestBody AlunoMedidaDTO dto) {
         return ResponseEntity.ok(ApiReturn.of(medidaService.adicionarMedida(uuid, dto)));
     }
 

--- a/src/main/java/com/example/demo/dto/AcademiaDTO.java
+++ b/src/main/java/com/example/demo/dto/AcademiaDTO.java
@@ -14,6 +14,7 @@ public class AcademiaDTO {
     private String telefone;
     private String codigo;
     private UsuarioDTO admin;
+    private Integer limiteAlunos;
 
     public UUID getUuid() {
         return uuid;
@@ -101,5 +102,13 @@ public class AcademiaDTO {
 
     public void setAdmin(UsuarioDTO admin) {
         this.admin = admin;
+    }
+
+    public Integer getLimiteAlunos() {
+        return limiteAlunos;
+    }
+
+    public void setLimiteAlunos(Integer limiteAlunos) {
+        this.limiteAlunos = limiteAlunos;
     }
 }

--- a/src/main/java/com/example/demo/dto/AlunoMedidaResultadoDTO.java
+++ b/src/main/java/com/example/demo/dto/AlunoMedidaResultadoDTO.java
@@ -1,0 +1,25 @@
+package com.example.demo.dto;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class AlunoMedidaResultadoDTO {
+    private AlunoMedidaDTO atual;
+    private Map<String, BigDecimal> variacoes;
+
+    public AlunoMedidaDTO getAtual() {
+        return atual;
+    }
+
+    public void setAtual(AlunoMedidaDTO atual) {
+        this.atual = atual;
+    }
+
+    public Map<String, BigDecimal> getVariacoes() {
+        return variacoes;
+    }
+
+    public void setVariacoes(Map<String, BigDecimal> variacoes) {
+        this.variacoes = variacoes;
+    }
+}

--- a/src/main/java/com/example/demo/entity/Academia.java
+++ b/src/main/java/com/example/demo/entity/Academia.java
@@ -29,6 +29,8 @@ public class Academia {
     @Column(nullable = false)
     private boolean ativo = true;
 
+    private Integer limiteAlunos;
+
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "admin_uuid", referencedColumnName = "uuid", nullable = false)
     private Usuario admin;

--- a/src/main/java/com/example/demo/repository/AlunoMedidaRepository.java
+++ b/src/main/java/com/example/demo/repository/AlunoMedidaRepository.java
@@ -3,9 +3,17 @@ package com.example.demo.repository;
 import com.example.demo.entity.AlunoMedida;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface AlunoMedidaRepository extends JpaRepository<AlunoMedida, UUID> {
     List<AlunoMedida> findByAlunoUuid(UUID alunoUuid);
+
+    Optional<AlunoMedida> findTopByAlunoUuidOrderByDataRegistroDesc(UUID alunoUuid);
+
+    List<AlunoMedida> findByAlunoUuidAndDataRegistroAfterOrderByDataRegistroDesc(UUID alunoUuid, LocalDateTime data);
+
+    void deleteByAlunoUuidAndDataRegistroBefore(UUID alunoUuid, LocalDateTime data);
 }

--- a/src/main/java/com/example/demo/repository/AlunoRepository.java
+++ b/src/main/java/com/example/demo/repository/AlunoRepository.java
@@ -24,4 +24,6 @@ public interface AlunoRepository extends JpaRepository<Aluno, UUID> {
 
     @Query("SELECT a FROM Aluno a WHERE a.academia.uuid = :academiaUuid AND (a.professor IS NULL OR a.professor.uuid <> :professorUuid) AND LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))")
     Page<Aluno> findByAcademiaUuidAndProfessorUuidNotOrProfessorIsNullAndNomeContainingIgnoreCase(UUID academiaUuid, UUID professorUuid, String nome, Pageable pageable);
+
+    long countByAcademiaUuid(UUID academiaUuid);
 }

--- a/src/main/java/com/example/demo/service/AcademiaService.java
+++ b/src/main/java/com/example/demo/service/AcademiaService.java
@@ -106,6 +106,7 @@ public class AcademiaService {
         entity.setBairro(dto.getBairro());
         entity.setTelefone(dto.getTelefone());
         entity.setCodigo(dto.getCodigo());
+        entity.setLimiteAlunos(dto.getLimiteAlunos());
 
         if (dto.getAdmin() != null && entity.getAdmin() != null) {
             entity.getAdmin().setNome(dto.getAdmin().getNome());


### PR DESCRIPTION
## Summary
- track measurement history with comparison to previous record and six-month retention
- add maximum student limit per academy

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f09a91588327b5620ad6314080cb