### PR TITLE
Implement training schedule and summary endpoint

### DIFF
--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+import java.time.LocalDate;
 
 @Tag(name = "Alunos")
 @Slf4j
@@ -154,5 +155,16 @@ public class AlunoController {
     public ResponseEntity<ApiReturn<Double>> registrarTreino(@Validated @RequestBody TreinoSessaoDTO dto) {
         UUID uuid = SecurityUtils.getUsuarioLogadoDetalhes().getUuid();
         return ResponseEntity.ok(ApiReturn.of(treinoSessaoService.registrarSessao(uuid, dto)));
+    }
+
+    @GetMapping("/treinos/resumo")
+    @PreAuthorize("hasRole('ALUNO')")
+    public ResponseEntity<ApiReturn<TreinoResumoDTO>> resumoTreinos(@RequestParam(required = false) Integer ano,
+                                                                    @RequestParam(required = false) Integer mes) {
+        UUID uuid = SecurityUtils.getUsuarioLogadoDetalhes().getUuid();
+        LocalDate now = LocalDate.now();
+        int year = ano != null ? ano : now.getYear();
+        int month = mes != null ? mes : now.getMonthValue();
+        return ResponseEntity.ok(ApiReturn.of(treinoSessaoService.resumoTreinos(uuid, year, month)));
     }
 }

--- a/src/main/java/com/example/demo/dto/TreinoDesempenhoDTO.java
+++ b/src/main/java/com/example/demo/dto/TreinoDesempenhoDTO.java
@@ -1,0 +1,24 @@
+package com.example.demo.dto;
+
+import java.time.LocalDate;
+
+public class TreinoDesempenhoDTO {
+    private LocalDate data;
+    private double percentual;
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    public double getPercentual() {
+        return percentual;
+    }
+
+    public void setPercentual(double percentual) {
+        this.percentual = percentual;
+    }
+}

--- a/src/main/java/com/example/demo/dto/TreinoResumoDTO.java
+++ b/src/main/java/com/example/demo/dto/TreinoResumoDTO.java
@@ -1,0 +1,24 @@
+package com.example.demo.dto;
+
+import java.util.List;
+
+public class TreinoResumoDTO {
+    private int diasConsecutivos;
+    private List<TreinoDesempenhoDTO> diasTreinados;
+
+    public int getDiasConsecutivos() {
+        return diasConsecutivos;
+    }
+
+    public void setDiasConsecutivos(int diasConsecutivos) {
+        this.diasConsecutivos = diasConsecutivos;
+    }
+
+    public List<TreinoDesempenhoDTO> getDiasTreinados() {
+        return diasTreinados;
+    }
+
+    public void setDiasTreinados(List<TreinoDesempenhoDTO> diasTreinados) {
+        this.diasTreinados = diasTreinados;
+    }
+}

--- a/src/main/java/com/example/demo/repository/TreinoDesempenhoRepository.java
+++ b/src/main/java/com/example/demo/repository/TreinoDesempenhoRepository.java
@@ -4,8 +4,14 @@ import com.example.demo.entity.TreinoDesempenho;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface TreinoDesempenhoRepository extends JpaRepository<TreinoDesempenho, UUID> {
+    Optional<TreinoDesempenho> findByAluno_UuidAndCategoria_UuidAndData(UUID alunoUuid, UUID categoriaUuid, LocalDate data);
+
+    List<TreinoDesempenho> findByAluno_UuidOrderByDataAsc(UUID alunoUuid);
+
+    List<TreinoDesempenho> findByAluno_UuidAndDataBetweenOrderByData(UUID alunoUuid, LocalDate inicio, LocalDate fim);
 }

--- a/src/main/java/com/example/demo/repository/TreinoSessaoRepository.java
+++ b/src/main/java/com/example/demo/repository/TreinoSessaoRepository.java
@@ -12,13 +12,21 @@ import java.util.UUID;
 public interface TreinoSessaoRepository extends JpaRepository<TreinoSessao, UUID> {
     List<TreinoSessao> findByAlunoUuid(UUID alunoUuid);
 
-    Optional<TreinoSessao> findByAluno_UuidAndUuidAndData(UUID alunoUuid, UUID exercicioUuid, LocalDate data);
+    Optional<TreinoSessao> findByAluno_UuidAndExercicio_UuidAndData(UUID alunoUuid, UUID exercicioUuid, LocalDate data);
+
+    Optional<TreinoSessao> findFirstByAluno_UuidAndExercicio_UuidAndStatusOrderByDataAsc(UUID alunoUuid, UUID exercicioUuid, StatusTreino status);
 
     long countByAlunoUuidAndExercicio_Categoria_UuidAndDataAndStatus(UUID alunoUuid, UUID categoriaUuid, LocalDate data, StatusTreino status);
 
     List<TreinoSessao> findByAlunoUuidAndData(UUID alunoUuid, LocalDate data);
 
+    List<TreinoSessao> findByAlunoUuidAndDataAfter(UUID alunoUuid, LocalDate data);
+
     List<TreinoSessao> findByAlunoUuidAndDataBeforeOrderByDataDesc(UUID alunoUuid, LocalDate data);
+
+    void deleteByAlunoUuidAndDataAfter(UUID alunoUuid, LocalDate data);
+
+    void deleteByAlunoUuid(UUID alunoUuid);
 
     boolean existsByExercicio_Uuid(UUID exercicioUuid);
 }

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -17,6 +17,7 @@ import com.example.demo.repository.ProfessorRepository;
 import com.example.demo.repository.UsuarioRepository;
 import com.example.demo.repository.TreinoSessaoRepository;
 import com.example.demo.repository.TreinoDesempenhoRepository;
+import com.example.demo.service.TreinoSessaoService;
 import com.example.demo.domain.enums.Perfil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,8 +45,9 @@ public class FichaTreinoService {
     private final NotificacaoService notificacaoService;
     private final TreinoSessaoRepository treinoSessaoRepository;
     private final TreinoDesempenhoRepository desempenhoRepository;
+    private final TreinoSessaoService treinoSessaoService;
 
-    public FichaTreinoService(FichaTreinoRepository repository, FichaTreinoMapper mapper, AlunoRepository alunoRepository, ProfessorRepository professorRepository, UsuarioRepository usuarioRepository, ExercicioRepository exercicioRepository, FichaTreinoHistoricoRepository historicoRepository, NotificacaoService notificacaoService, TreinoSessaoRepository treinoSessaoRepository, TreinoDesempenhoRepository desempenhoRepository) {
+    public FichaTreinoService(FichaTreinoRepository repository, FichaTreinoMapper mapper, AlunoRepository alunoRepository, ProfessorRepository professorRepository, UsuarioRepository usuarioRepository, ExercicioRepository exercicioRepository, FichaTreinoHistoricoRepository historicoRepository, NotificacaoService notificacaoService, TreinoSessaoRepository treinoSessaoRepository, TreinoDesempenhoRepository desempenhoRepository, TreinoSessaoService treinoSessaoService) {
         this.repository = repository;
         this.mapper = mapper;
         this.alunoRepository = alunoRepository;
@@ -56,6 +58,7 @@ public class FichaTreinoService {
         this.notificacaoService = notificacaoService;
         this.treinoSessaoRepository = treinoSessaoRepository;
         this.desempenhoRepository = desempenhoRepository;
+        this.treinoSessaoService = treinoSessaoService;
     }
 
     @Transactional
@@ -85,6 +88,10 @@ public class FichaTreinoService {
         repository.save(ficha);
 
         if (isNew) {
+            if (aluno != null) {
+                treinoSessaoRepository.deleteByAlunoUuid(aluno.getUuid());
+                treinoSessaoService.gerarSessoesFuturas(ficha, LocalDate.now(), 0);
+            }
             salvarHistoricoSeNecessario(ficha);
             if (aluno != null) {
                 notificacaoService.notificarNovaFichaTreino(aluno);

--- a/src/main/java/com/example/demo/service/TreinoSessaoService.java
+++ b/src/main/java/com/example/demo/service/TreinoSessaoService.java
@@ -1,6 +1,6 @@
 package com.example.demo.service;
 
-import com.example.demo.dto.TreinoSessaoDTO;
+import com.example.demo.dto.*;
 import com.example.demo.entity.*;
 import com.example.demo.exception.ApiException;
 import com.example.demo.mapper.TreinoSessaoMapper;
@@ -59,44 +59,120 @@ public class TreinoSessaoService {
                 .orElseThrow(() -> new ApiException("Exercício não encontrado na ficha do aluno"));
 
         TreinoSessao sessao = repository
-                .findByAluno_UuidAndUuidAndData(alunoUuid, dto.getExercicioUuid(), LocalDate.now())
+                .findByAluno_UuidAndExercicio_UuidAndData(alunoUuid, dto.getExercicioUuid(), LocalDate.now())
                 .orElse(null);
+
+        if (sessao == null) {
+            sessao = repository.findFirstByAluno_UuidAndExercicio_UuidAndStatusOrderByDataAsc(alunoUuid, dto.getExercicioUuid(), StatusTreino.PENDENTE)
+                    .orElse(null);
+            if (sessao != null && sessao.getData().isAfter(LocalDate.now())) {
+                List<TreinoSessao> mesmasDatas = repository.findByAlunoUuidAndData(alunoUuid, sessao.getData());
+                mesmasDatas.forEach(s -> s.setData(LocalDate.now()));
+            }
+        }
 
         if (sessao == null) {
             sessao = mapper.toEntity(dto);
             sessao.setAluno(aluno);
             sessao.setExercicio(exercicio);
             sessao.setData(LocalDate.now());
-            sessao.setStatus(StatusTreino.CONCLUIDO);
-        } else if (sessao.getStatus() == StatusTreino.CONCLUIDO) {
-            repository.delete(sessao);
-        } else {
-            sessao.setRepeticoesRealizadas(dto.getRepeticoesRealizadas());
-            sessao.setData(LocalDate.now());
-            sessao.setCargaRealizada(dto.getCargaRealizada());
-            sessao.setStatus(StatusTreino.CONCLUIDO);
         }
+
+        sessao.setRepeticoesRealizadas(dto.getRepeticoesRealizadas());
+        sessao.setCargaRealizada(dto.getCargaRealizada());
+        sessao.setStatus(StatusTreino.CONCLUIDO);
 
         repository.save(sessao);
 
         FichaTreinoCategoria categoria = exercicio.getCategoria();
         int total = categoria.getExercicios().size();
-        long realizados = repository.countByAlunoUuidAndExercicio_Categoria_UuidAndDataAndStatus(alunoUuid, categoria.getUuid(), dto.getData(), StatusTreino.CONCLUIDO);
+        long realizados = repository.countByAlunoUuidAndExercicio_Categoria_UuidAndDataAndStatus(alunoUuid, categoria.getUuid(), LocalDate.now(), StatusTreino.CONCLUIDO);
         double percentual = (double) realizados / total * 100.0;
 
-//        TreinoDesempenho desempenho = desempenhoRepository
-//                .findByAluno_UuidAndCategoria_UuidAndData(alunoUuid, categoria.getUuid(), LocalDate.now())
-//                .orElseGet(() -> {
-//                    TreinoDesempenho d = new TreinoDesempenho();
-//                    d.setAluno(aluno);
-//                    d.setCategoria(categoria);
-//                    d.setData(LocalDate.now());
-//                    return d;
-//                });
-//        desempenho.setPercentual(percentual);
-//        desempenhoRepository.save(desempenho);
+        TreinoDesempenho desempenho = desempenhoRepository
+                .findByAluno_UuidAndCategoria_UuidAndData(alunoUuid, categoria.getUuid(), LocalDate.now())
+                .orElseGet(() -> {
+                    TreinoDesempenho d = new TreinoDesempenho();
+                    d.setAluno(aluno);
+                    d.setCategoria(categoria);
+                    d.setData(LocalDate.now());
+                    return d;
+                });
+        desempenho.setPercentual(percentual);
+        desempenhoRepository.save(desempenho);
+
+        FichaTreino ficha = categoria.getFicha();
+        repository.deleteByAlunoUuidAndDataAfter(alunoUuid, LocalDate.now());
+        List<FichaTreinoCategoria> categorias = ficha.getCategorias();
+        int idx = categorias.indexOf(categoria);
+        gerarSessoesFuturas(ficha, LocalDate.now().plusDays(1), idx + 1);
 
         return percentual;
+    }
+
+    public void gerarSessoesFuturas(FichaTreino ficha, LocalDate inicio, int startIndex) {
+        List<FichaTreinoCategoria> categorias = ficha.getCategorias();
+        if (categorias == null || categorias.isEmpty()) return;
+        Aluno aluno = ficha.getAluno();
+        LocalDate data = inicio;
+        LocalDate fim = inicio.withDayOfMonth(inicio.lengthOfMonth());
+        int idx = startIndex;
+        while (!data.isAfter(fim)) {
+            FichaTreinoCategoria cat = categorias.get(idx % categorias.size());
+            for (FichaTreinoExercicio fe : cat.getExercicios()) {
+                TreinoSessao s = new TreinoSessao();
+                s.setAluno(aluno);
+                s.setExercicio(fe);
+                s.setData(data);
+                s.setStatus(StatusTreino.PENDENTE);
+                repository.save(s);
+            }
+            data = data.plusDays(1);
+            idx++;
+        }
+    }
+
+    public TreinoResumoDTO resumoTreinos(UUID alunoUuid, int ano, int mes) {
+        LocalDate inicio = LocalDate.of(ano, mes, 1);
+        LocalDate fim = inicio.withDayOfMonth(inicio.lengthOfMonth());
+
+        List<TreinoDesempenhoDTO> diasTreinados = desempenhoRepository
+                .findByAluno_UuidAndDataBetweenOrderByData(alunoUuid, inicio, fim).stream()
+                .map(d -> {
+                    TreinoDesempenhoDTO td = new TreinoDesempenhoDTO();
+                    td.setData(d.getData());
+                    td.setPercentual(d.getPercentual());
+                    return td;
+                }).collect(Collectors.toList());
+
+        List<TreinoDesempenho> todos = desempenhoRepository.findByAluno_UuidOrderByDataAsc(alunoUuid);
+        int streak = calcularStreak(todos.stream().map(TreinoDesempenho::getData).toList(), LocalDate.now());
+
+        TreinoResumoDTO resumo = new TreinoResumoDTO();
+        resumo.setDiasConsecutivos(streak);
+        resumo.setDiasTreinados(diasTreinados);
+        return resumo;
+    }
+
+    private int calcularStreak(List<LocalDate> dias, LocalDate hoje) {
+        int streak = 0;
+        LocalDate data = hoje;
+        while (true) {
+            if (dias.contains(data)) {
+                streak++;
+            } else {
+                switch (data.getDayOfWeek()) {
+                    case SATURDAY, SUNDAY -> {
+                        data = data.minusDays(1);
+                        continue;
+                    }
+                    default -> {
+                        return streak;
+                    }
+                }
+            }
+            data = data.minusDays(1);
+        }
     }
 
     private void validarMesmaAcademia(Aluno aluno) {


### PR DESCRIPTION
## Summary
- generate daily training sessions through month when assigning a training plan
- record session performance and reschedule remaining sessions to keep sequence
- expose `/alunos/treinos/resumo` endpoint returning consecutive days and monthly performance

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7293934e0832780dee14d8f58f65b