### PR TITLE
feat: add category listing endpoint

### DIFF
--- a/src/main/java/com/example/demo/controller/FichaTreinoController.java
+++ b/src/main/java/com/example/demo/controller/FichaTreinoController.java
@@ -2,11 +2,10 @@ package com.example.demo.controller;
 
 import com.example.demo.common.response.ApiReturn;
 import com.example.demo.common.security.SecurityUtils;
+import com.example.demo.dto.CategoriaListagemDTO;
 import com.example.demo.dto.FichaTreinoDTO;
 import com.example.demo.dto.FichaTreinoHistoricoDTO;
 import com.example.demo.service.FichaTreinoService;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -69,5 +68,11 @@ public class FichaTreinoController {
     @PutMapping("/ficha-atual/{fichaUuid}")
     public ResponseEntity<ApiReturn<String>> atualizarFichaAtual(@PathVariable UUID fichaUuid) {
         return ResponseEntity.ok(ApiReturn.of(service.atualizarFichaAtual(fichaUuid)));
+    }
+    
+    @GetMapping("/listagem")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN','PROFESSOR','ALUNO')")
+    public ResponseEntity<ApiReturn<List<CategoriaListagemDTO>>> listagem(@RequestParam(required = false) UUID usuarioUuid) {
+        return ResponseEntity.ok(ApiReturn.of(service.listarCategorias(usuarioUuid)));
     }
 }

--- a/src/main/java/com/example/demo/dto/CategoriaListagemDTO.java
+++ b/src/main/java/com/example/demo/dto/CategoriaListagemDTO.java
@@ -1,0 +1,36 @@
+package com.example.demo.dto;
+
+import com.example.demo.entity.Musculo;
+
+import java.util.List;
+import java.util.UUID;
+
+public class CategoriaListagemDTO {
+    private UUID uuid;
+    private String nome;
+    private List<Musculo> musculos;
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public List<Musculo> getMusculos() {
+        return musculos;
+    }
+
+    public void setMusculos(List<Musculo> musculos) {
+        this.musculos = musculos;
+    }
+}

--- a/src/main/java/com/example/demo/service/FichaTreinoService.java
+++ b/src/main/java/com/example/demo/service/FichaTreinoService.java
@@ -6,6 +6,7 @@ import com.example.demo.dto.FichaTreinoDTO;
 import com.example.demo.dto.FichaTreinoCategoriaDTO;
 import com.example.demo.dto.FichaTreinoHistoricoDTO;
 import com.example.demo.dto.FichaTreinoExercicioDTO;
+import com.example.demo.dto.CategoriaListagemDTO;
 import com.example.demo.entity.*;
 import com.example.demo.exception.ApiException;
 import com.example.demo.mapper.FichaTreinoMapper;
@@ -385,6 +386,35 @@ public class FichaTreinoService {
         });
 
         return dto;
+    }
+
+    public List<CategoriaListagemDTO> listarCategorias(UUID usuarioUuid) {
+        UUID alunoUuid = usuarioUuid;
+        if (alunoUuid == null) {
+            UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
+            if (usuario == null) {
+                throw new ApiException("Usuário não autenticado");
+            }
+            alunoUuid = usuario.getUuid();
+        }
+
+        FichaTreinoDTO ficha = findCurrentByAluno(alunoUuid);
+
+        if (ficha.getCategorias() == null) {
+            return new ArrayList<>();
+        }
+
+        return ficha.getCategorias().stream().map(c -> {
+            CategoriaListagemDTO dto = new CategoriaListagemDTO();
+            dto.setUuid(c.getUuid());
+            dto.setNome(c.getNome());
+            List<Musculo> musculos = c.getExercicios().stream()
+                    .map(FichaTreinoExercicioDTO::getMusculo)
+                    .distinct()
+                    .collect(Collectors.toList());
+            dto.setMusculos(musculos);
+            return dto;
+        }).collect(Collectors.toList());
     }
 
     public List<FichaTreinoDTO> findPresetsByProfessor() {


### PR DESCRIPTION
## Summary
- add DTO for category listing with muscles
- implement service method to gather categories and muscles for a user
- expose `/fichas/listagem` endpoint accessible to admin, professor, and aluno

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa50a567ac8327840f1037b32e356c