### PR TITLE
Add supplier store type classification

### DIFF
--- a/src/main/java/com/example/demo/domain/enums/TipoFornecedor.java
+++ b/src/main/java/com/example/demo/domain/enums/TipoFornecedor.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.enums;
+
+public enum TipoFornecedor {
+    SUPLEMENTO,
+    VESTUARIO
+}

--- a/src/main/java/com/example/demo/dto/FornecedorDTO.java
+++ b/src/main/java/com/example/demo/dto/FornecedorDTO.java
@@ -1,5 +1,16 @@
 package com.example.demo.dto;
 
+import com.example.demo.domain.enums.TipoFornecedor;
+
 public class FornecedorDTO extends UsuarioDTO {
+    private TipoFornecedor tipo;
+
+    public TipoFornecedor getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(TipoFornecedor tipo) {
+        this.tipo = tipo;
+    }
 }
 

--- a/src/main/java/com/example/demo/entity/Fornecedor.java
+++ b/src/main/java/com/example/demo/entity/Fornecedor.java
@@ -1,5 +1,6 @@
 package com.example.demo.entity;
 
+import com.example.demo.domain.enums.TipoFornecedor;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -9,6 +10,9 @@ import java.util.List;
 @Entity
 @DiscriminatorValue("FORNECEDOR")
 public class Fornecedor extends Usuario {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_fornecedor", nullable = false)
+    private TipoFornecedor tipo;
 
     @OneToMany(mappedBy = "fornecedor", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Produto> produtos;

--- a/src/main/java/com/example/demo/service/FornecedorService.java
+++ b/src/main/java/com/example/demo/service/FornecedorService.java
@@ -41,6 +41,7 @@ public class FornecedorService {
     @Transactional
     public String create(FornecedorDTO dto) {
         Fornecedor entity = mapper.toEntity(dto);
+        entity.setTipo(dto.getTipo());
         entity.setNumero(dto.getNumero());
         entity.setCep(dto.getCep());
         entity.setLogradouro(dto.getLogradouro());
@@ -93,6 +94,7 @@ public class FornecedorService {
         entity.setLogradouro(dto.getLogradouro());
         entity.setUf(dto.getUf());
         entity.setCidade(dto.getCidade());
+        entity.setTipo(dto.getTipo());
         repository.save(entity);
         return "Fornecedor atualizado";
     }


### PR DESCRIPTION
## Summary
- add `TipoFornecedor` enum with SUPLEMENTO and VESTUARIO
- store supplier type in `Fornecedor` entity and DTO
- persist and update supplier type in `FornecedorService`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acf461050083279b9d43b5dca7cd42