### PR TITLE
feat: add product filtering

### DIFF
--- a/src/main/java/com/example/demo/controller/ProdutoController.java
+++ b/src/main/java/com/example/demo/controller/ProdutoController.java
@@ -4,6 +4,7 @@ import com.example.demo.common.response.ApiReturn;
 import com.example.demo.common.security.SecurityUtils;
 import com.example.demo.common.security.UsuarioLogado;
 import com.example.demo.dto.ProdutoDTO;
+import com.example.demo.dto.ProdutoFiltroDTO;
 import com.example.demo.service.ProdutoService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
@@ -38,6 +39,12 @@ public class ProdutoController {
     public ResponseEntity<ApiReturn<Page<ProdutoDTO>>> listar(Pageable pageable) {
         UsuarioLogado usuarioLogado = SecurityUtils.getUsuarioLogadoDetalhes();
         return ResponseEntity.ok(ApiReturn.of(service.findByFornecedor(usuarioLogado.getUuid(), pageable)));
+    }
+
+    @PostMapping("/filtro")
+    public ResponseEntity<ApiReturn<Page<ProdutoDTO>>> filtrar(@RequestBody ProdutoFiltroDTO filtro,
+                                                               Pageable pageable) {
+        return ResponseEntity.ok(ApiReturn.of(service.filtrar(filtro, pageable)));
     }
 
     @GetMapping("/{uuid}")

--- a/src/main/java/com/example/demo/dto/ProdutoFiltroDTO.java
+++ b/src/main/java/com/example/demo/dto/ProdutoFiltroDTO.java
@@ -1,0 +1,89 @@
+package com.example.demo.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class ProdutoFiltroDTO {
+    private String nome;
+    private BigDecimal precoMin;
+    private BigDecimal precoMax;
+    private List<String> tamanhos;
+    private List<String> cores;
+    private List<String> sabores;
+    private List<String> volumes;
+    private Boolean promocao;
+    private List<String> marcas;
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public BigDecimal getPrecoMin() {
+        return precoMin;
+    }
+
+    public void setPrecoMin(BigDecimal precoMin) {
+        this.precoMin = precoMin;
+    }
+
+    public BigDecimal getPrecoMax() {
+        return precoMax;
+    }
+
+    public void setPrecoMax(BigDecimal precoMax) {
+        this.precoMax = precoMax;
+    }
+
+    public List<String> getTamanhos() {
+        return tamanhos;
+    }
+
+    public void setTamanhos(List<String> tamanhos) {
+        this.tamanhos = tamanhos;
+    }
+
+    public List<String> getCores() {
+        return cores;
+    }
+
+    public void setCores(List<String> cores) {
+        this.cores = cores;
+    }
+
+    public List<String> getSabores() {
+        return sabores;
+    }
+
+    public void setSabores(List<String> sabores) {
+        this.sabores = sabores;
+    }
+
+    public List<String> getVolumes() {
+        return volumes;
+    }
+
+    public void setVolumes(List<String> volumes) {
+        this.volumes = volumes;
+    }
+
+    public Boolean getPromocao() {
+        return promocao;
+    }
+
+    public void setPromocao(Boolean promocao) {
+        this.promocao = promocao;
+    }
+
+    public List<String> getMarcas() {
+        return marcas;
+    }
+
+    public void setMarcas(List<String> marcas) {
+        this.marcas = marcas;
+    }
+}
+

--- a/src/main/java/com/example/demo/repository/ProdutoRepository.java
+++ b/src/main/java/com/example/demo/repository/ProdutoRepository.java
@@ -4,10 +4,11 @@ import com.example.demo.entity.Produto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.UUID;
 
-public interface ProdutoRepository extends JpaRepository<Produto, UUID> {
+public interface ProdutoRepository extends JpaRepository<Produto, UUID>, JpaSpecificationExecutor<Produto> {
     Page<Produto> findByFornecedorUuid(UUID fornecedorUuid, Pageable pageable);
 }
 

--- a/src/main/java/com/example/demo/service/ProdutoService.java
+++ b/src/main/java/com/example/demo/service/ProdutoService.java
@@ -4,8 +4,10 @@ import com.example.demo.common.security.SecurityUtils;
 import com.example.demo.common.security.UsuarioLogado;
 import com.example.demo.domain.enums.Perfil;
 import com.example.demo.dto.ProdutoDTO;
+import com.example.demo.dto.ProdutoFiltroDTO;
 import com.example.demo.entity.Fornecedor;
 import com.example.demo.entity.Produto;
+import com.example.demo.entity.ProdutoDetalhe;
 import com.example.demo.exception.ApiException;
 import com.example.demo.mapper.ProdutoMapper;
 import com.example.demo.repository.FornecedorRepository;
@@ -13,9 +15,16 @@ import com.example.demo.repository.ProdutoRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -61,6 +70,54 @@ public class ProdutoService {
     public Page<ProdutoDTO> findByFornecedor(UUID fornecedorUuid, Pageable pageable) {
         return repository.findByFornecedorUuid(fornecedorUuid, pageable)
                 .map(mapper::toDto);
+    }
+
+    public Page<ProdutoDTO> filtrar(ProdutoFiltroDTO filtro, Pageable pageable) {
+        Specification<Produto> spec = (root, query, cb) -> {
+            query.distinct(true);
+            Join<Produto, ProdutoDetalhe> detalhe = root.join("detalhe", JoinType.LEFT);
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (filtro.getNome() != null && !filtro.getNome().isBlank()) {
+                predicates.add(cb.like(cb.lower(root.get("nome")), "%" + filtro.getNome().toLowerCase() + "%"));
+            }
+
+            if (filtro.getMarcas() != null && !filtro.getMarcas().isEmpty()) {
+                predicates.add(root.get("marca").in(filtro.getMarcas()));
+            }
+
+            if (filtro.getTamanhos() != null && !filtro.getTamanhos().isEmpty()) {
+                predicates.add(detalhe.get("tamanho").in(filtro.getTamanhos()));
+            }
+
+            if (filtro.getCores() != null && !filtro.getCores().isEmpty()) {
+                predicates.add(detalhe.get("cor").in(filtro.getCores()));
+            }
+
+            if (filtro.getSabores() != null && !filtro.getSabores().isEmpty()) {
+                predicates.add(detalhe.get("sabor").in(filtro.getSabores()));
+            }
+
+            if (filtro.getVolumes() != null && !filtro.getVolumes().isEmpty()) {
+                predicates.add(detalhe.get("volume").in(filtro.getVolumes()));
+            }
+
+            if (filtro.getPromocao() != null) {
+                predicates.add(cb.equal(detalhe.get("promocao"), filtro.getPromocao()));
+            }
+
+            if (filtro.getPrecoMin() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(detalhe.get("preco"), filtro.getPrecoMin()));
+            }
+
+            if (filtro.getPrecoMax() != null) {
+                predicates.add(cb.lessThanOrEqualTo(detalhe.get("preco"), filtro.getPrecoMax()));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        return repository.findAll(spec, pageable).map(mapper::toDto);
     }
 
     public ProdutoDTO findByUuid(UUID uuid) {


### PR DESCRIPTION
## Summary
- add DTO for product search filters
- enable spec queries on ProdutoRepository
- expose service and controller endpoints to filter products by name, price, attributes and promo flag

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adbb3815308327ae1b66dbd9fe31a1