### PR TITLE
Add optional CREF fields and professor search filters

### DIFF
--- a/src/main/java/com/example/demo/controller/ProfessorController.java
+++ b/src/main/java/com/example/demo/controller/ProfessorController.java
@@ -35,9 +35,12 @@ public class ProfessorController {
 
     @GetMapping
     @PreAuthorize("hasAnyRole('MASTER','ADMIN')")
-    public ResponseEntity<ApiReturn<Page<ProfessorDTO>>> listar(@RequestParam(required = false) String nome,
-                                                                Pageable pageable) {
-        return ResponseEntity.ok(ApiReturn.of(service.findAll(nome, pageable)));
+    public ResponseEntity<ApiReturn<Page<ProfessorDTO>>> listar(
+            @RequestParam(required = false) String nome,
+            @RequestParam(required = false) UUID alunoUuid,
+            @RequestParam(required = false) Boolean possuiCref,
+            Pageable pageable) {
+        return ResponseEntity.ok(ApiReturn.of(service.findAll(nome, alunoUuid, possuiCref, pageable)));
     }
 
     @GetMapping("/{uuid}")

--- a/src/main/java/com/example/demo/dto/ProfessorDTO.java
+++ b/src/main/java/com/example/demo/dto/ProfessorDTO.java
@@ -1,4 +1,24 @@
 package com.example.demo.dto;
 
+import java.time.LocalDate;
+
 public class ProfessorDTO extends UsuarioDTO {
+    private String cref;
+    private LocalDate crefValidade;
+
+    public String getCref() {
+        return cref;
+    }
+
+    public void setCref(String cref) {
+        this.cref = cref;
+    }
+
+    public LocalDate getCrefValidade() {
+        return crefValidade;
+    }
+
+    public void setCrefValidade(LocalDate crefValidade) {
+        this.crefValidade = crefValidade;
+    }
 }

--- a/src/main/java/com/example/demo/entity/Professor.java
+++ b/src/main/java/com/example/demo/entity/Professor.java
@@ -4,8 +4,13 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.Data;
 
+import java.time.LocalDate;
+
 @Data
 @Entity
 @DiscriminatorValue("PROFESSOR")
 public class Professor extends Usuario {
+    private String cref;
+
+    private LocalDate crefValidade;
 }

--- a/src/main/java/com/example/demo/repository/ProfessorRepository.java
+++ b/src/main/java/com/example/demo/repository/ProfessorRepository.java
@@ -13,4 +13,20 @@ public interface ProfessorRepository extends JpaRepository<Professor, UUID> {
     Page<Professor> findByNomeContainingIgnoreCase(String nome, Pageable pageable);
 
     Page<Professor> findByAcademiaUuidAndNomeContainingIgnoreCase(UUID uuid, String nome, Pageable pageable);
+
+    Page<Professor> findByCrefIsNotNull(Pageable pageable);
+
+    Page<Professor> findByCrefIsNull(Pageable pageable);
+
+    Page<Professor> findByNomeContainingIgnoreCaseAndCrefIsNotNull(String nome, Pageable pageable);
+
+    Page<Professor> findByNomeContainingIgnoreCaseAndCrefIsNull(String nome, Pageable pageable);
+
+    Page<Professor> findByAcademiaUuidAndCrefIsNotNull(UUID uuid, Pageable pageable);
+
+    Page<Professor> findByAcademiaUuidAndCrefIsNull(UUID uuid, Pageable pageable);
+
+    Page<Professor> findByAcademiaUuidAndNomeContainingIgnoreCaseAndCrefIsNotNull(UUID uuid, String nome, Pageable pageable);
+
+    Page<Professor> findByAcademiaUuidAndNomeContainingIgnoreCaseAndCrefIsNull(UUID uuid, String nome, Pageable pageable);
 }


### PR DESCRIPTION
## Summary
- allow storing optional CREF registration and validity for professors
- support filtering professors by associated student and by presence of CREF

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af4de36308832785aca5cf49cb7dc7