### PR TITLE
feat: add product favorites

### DIFF
--- a/src/main/java/com/example/demo/controller/FavoritoController.java
+++ b/src/main/java/com/example/demo/controller/FavoritoController.java
@@ -1,0 +1,42 @@
+package com.example.demo.controller;
+
+import com.example.demo.common.response.ApiReturn;
+import com.example.demo.dto.ProdutoDTO;
+import com.example.demo.service.ProdutoFavoritoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "Favoritos")
+@RestController
+@RequestMapping("/favoritos")
+public class FavoritoController {
+    private final ProdutoFavoritoService service;
+
+    public FavoritoController(ProdutoFavoritoService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{produtoUuid}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiReturn<String>> favoritar(@PathVariable UUID produtoUuid) {
+        return ResponseEntity.ok(ApiReturn.of(service.favoritar(produtoUuid)));
+    }
+
+    @DeleteMapping("/{produtoUuid}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiReturn<String>> desfavoritar(@PathVariable UUID produtoUuid) {
+        return ResponseEntity.ok(ApiReturn.of(service.desfavoritar(produtoUuid)));
+    }
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiReturn<Page<ProdutoDTO>>> listar(Pageable pageable) {
+        return ResponseEntity.ok(ApiReturn.of(service.listar(pageable)));
+    }
+}

--- a/src/main/java/com/example/demo/entity/Produto.java
+++ b/src/main/java/com/example/demo/entity/Produto.java
@@ -24,6 +24,9 @@ public class Produto {
     @OneToMany(mappedBy = "produto", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProdutoDetalhe> detalhe;
 
+    @OneToMany(mappedBy = "produto", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProdutoFavorito> favoritos;
+
     private boolean ativo = true;
 
     @PrePersist

--- a/src/main/java/com/example/demo/entity/ProdutoFavorito.java
+++ b/src/main/java/com/example/demo/entity/ProdutoFavorito.java
@@ -1,0 +1,29 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Entity
+public class ProdutoFavorito {
+    @Id
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID uuid;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "usuario_uuid", nullable = false)
+    private Usuario usuario;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "produto_uuid", nullable = false)
+    private Produto produto;
+
+    @PrePersist
+    private void gerarUuid() {
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/repository/ProdutoFavoritoRepository.java
+++ b/src/main/java/com/example/demo/repository/ProdutoFavoritoRepository.java
@@ -1,0 +1,13 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.ProdutoFavorito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface ProdutoFavoritoRepository extends BaseRepository<ProdutoFavorito, UUID> {
+    boolean existsByUsuarioUuidAndProdutoUuid(UUID usuarioUuid, UUID produtoUuid);
+    void deleteByUsuarioUuidAndProdutoUuid(UUID usuarioUuid, UUID produtoUuid);
+    Page<ProdutoFavorito> findByUsuarioUuid(UUID usuarioUuid, Pageable pageable);
+}

--- a/src/main/java/com/example/demo/service/ProdutoFavoritoService.java
+++ b/src/main/java/com/example/demo/service/ProdutoFavoritoService.java
@@ -1,0 +1,80 @@
+package com.example.demo.service;
+
+import com.example.demo.common.security.SecurityUtils;
+import com.example.demo.common.security.UsuarioLogado;
+import com.example.demo.dto.ProdutoDTO;
+import com.example.demo.entity.Produto;
+import com.example.demo.entity.ProdutoFavorito;
+import com.example.demo.entity.Usuario;
+import com.example.demo.exception.ApiException;
+import com.example.demo.mapper.ProdutoMapper;
+import com.example.demo.repository.ProdutoFavoritoRepository;
+import com.example.demo.repository.ProdutoRepository;
+import com.example.demo.repository.UsuarioRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class ProdutoFavoritoService {
+    private final ProdutoFavoritoRepository repository;
+    private final ProdutoRepository produtoRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final ProdutoMapper produtoMapper;
+
+    public ProdutoFavoritoService(ProdutoFavoritoRepository repository,
+                                  ProdutoRepository produtoRepository,
+                                  UsuarioRepository usuarioRepository,
+                                  ProdutoMapper produtoMapper) {
+        this.repository = repository;
+        this.produtoRepository = produtoRepository;
+        this.usuarioRepository = usuarioRepository;
+        this.produtoMapper = produtoMapper;
+    }
+
+    @Transactional
+    public String favoritar(UUID produtoUuid) {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
+        if (usuario == null) {
+            throw new ApiException("Usuário não autenticado");
+        }
+
+        if (repository.existsByUsuarioUuidAndProdutoUuid(usuario.getUuid(), produtoUuid)) {
+            return "Produto já favoritado";
+        }
+
+        Usuario usuarioEntity = usuarioRepository.findById(usuario.getUuid())
+                .orElseThrow(() -> new ApiException("Usuário não encontrado"));
+        Produto produto = produtoRepository.findById(produtoUuid)
+                .orElseThrow(() -> new ApiException("Produto não encontrado"));
+
+        ProdutoFavorito favorito = new ProdutoFavorito();
+        favorito.setUsuario(usuarioEntity);
+        favorito.setProduto(produto);
+        repository.save(favorito);
+        return "Produto favoritado";
+    }
+
+    @Transactional
+    public String desfavoritar(UUID produtoUuid) {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
+        if (usuario == null) {
+            throw new ApiException("Usuário não autenticado");
+        }
+        repository.deleteByUsuarioUuidAndProdutoUuid(usuario.getUuid(), produtoUuid);
+        return "Produto removido dos favoritos";
+    }
+
+    public Page<ProdutoDTO> listar(Pageable pageable) {
+        UsuarioLogado usuario = SecurityUtils.getUsuarioLogadoDetalhes();
+        if (usuario == null) {
+            throw new ApiException("Usuário não autenticado");
+        }
+
+        return repository.findByUsuarioUuid(usuario.getUuid(), pageable)
+                .map(f -> produtoMapper.toDto(f.getProduto()));
+    }
+}


### PR DESCRIPTION
## Summary
- add entity and repository for product favorites
- expose REST endpoints to favorite, unfavorite and list products
- ensure favorites removed when product is deleted

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af96c0e8088327a636c98a2e4f498d