### PR TITLE
Add delivery address handling to Mercado Pago payments

### DIFF
--- a/src/main/java/com/example/demo/dto/EnderecoDTO.java
+++ b/src/main/java/com/example/demo/dto/EnderecoDTO.java
@@ -1,0 +1,49 @@
+package com.example.demo.dto;
+
+public class EnderecoDTO {
+    private String logradouro;
+    private String bairro;
+    private String cidade;
+    private String uf;
+    private String cep;
+
+    public String getLogradouro() {
+        return logradouro;
+    }
+
+    public void setLogradouro(String logradouro) {
+        this.logradouro = logradouro;
+    }
+
+    public String getBairro() {
+        return bairro;
+    }
+
+    public void setBairro(String bairro) {
+        this.bairro = bairro;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public void setCidade(String cidade) {
+        this.cidade = cidade;
+    }
+
+    public String getUf() {
+        return uf;
+    }
+
+    public void setUf(String uf) {
+        this.uf = uf;
+    }
+
+    public String getCep() {
+        return cep;
+    }
+
+    public void setCep(String cep) {
+        this.cep = cep;
+    }
+}

--- a/src/main/java/com/example/demo/dto/MercadoPagoCartaoDTO.java
+++ b/src/main/java/com/example/demo/dto/MercadoPagoCartaoDTO.java
@@ -1,6 +1,7 @@
 package com.example.demo.dto;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 public class MercadoPagoCartaoDTO {
     private String token;
@@ -11,6 +12,10 @@ public class MercadoPagoCartaoDTO {
     private String email;
     private String docType;
     private String docNumber;
+
+    private UUID enderecoUuid;
+
+    private EnderecoDTO endereco;
 
     public String getToken() {
         return token;
@@ -74,5 +79,21 @@ public class MercadoPagoCartaoDTO {
 
     public void setDocNumber(String docNumber) {
         this.docNumber = docNumber;
+    }
+
+    public UUID getEnderecoUuid() {
+        return enderecoUuid;
+    }
+
+    public void setEnderecoUuid(UUID enderecoUuid) {
+        this.enderecoUuid = enderecoUuid;
+    }
+
+    public EnderecoDTO getEndereco() {
+        return endereco;
+    }
+
+    public void setEndereco(EnderecoDTO endereco) {
+        this.endereco = endereco;
     }
 }

--- a/src/main/java/com/example/demo/dto/MercadoPagoQrCodeDTO.java
+++ b/src/main/java/com/example/demo/dto/MercadoPagoQrCodeDTO.java
@@ -1,10 +1,15 @@
 package com.example.demo.dto;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 public class MercadoPagoQrCodeDTO {
     private String descricao;
     private BigDecimal valor;
+
+    private UUID enderecoUuid;
+
+    private EnderecoDTO endereco;
 
     public String getDescricao() {
         return descricao;
@@ -20,5 +25,21 @@ public class MercadoPagoQrCodeDTO {
 
     public void setValor(BigDecimal valor) {
         this.valor = valor;
+    }
+
+    public UUID getEnderecoUuid() {
+        return enderecoUuid;
+    }
+
+    public void setEnderecoUuid(UUID enderecoUuid) {
+        this.enderecoUuid = enderecoUuid;
+    }
+
+    public EnderecoDTO getEndereco() {
+        return endereco;
+    }
+
+    public void setEndereco(EnderecoDTO endereco) {
+        this.endereco = endereco;
     }
 }

--- a/src/main/java/com/example/demo/entity/Endereco.java
+++ b/src/main/java/com/example/demo/entity/Endereco.java
@@ -5,31 +5,22 @@ import lombok.Data;
 
 import java.util.UUID;
 
-/**
- * Pagamento registrado no Mercado Pago com associação ao usuário e endereço de entrega.
- */
-
 @Data
 @Entity
-public class MercadoPagoPagamento {
+public class Endereco {
 
     @Id
     @Column(nullable = false, unique = true, updatable = false)
     private UUID uuid;
 
-    private String mercadoPagoId;
-
-    private String status;
-
-    private String tipo;
-
-    private String detalhe;
-
     @ManyToOne(optional = false)
     private Usuario usuario;
 
-    @ManyToOne(optional = false)
-    private Endereco endereco;
+    private String logradouro;
+    private String bairro;
+    private String cidade;
+    private String uf;
+    private String cep;
 
     @PrePersist
     private void prePersist() {

--- a/src/main/java/com/example/demo/repository/EnderecoRepository.java
+++ b/src/main/java/com/example/demo/repository/EnderecoRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Endereco;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface EnderecoRepository extends JpaRepository<Endereco, UUID> {
+}


### PR DESCRIPTION
## Summary
- capture logged user and shipping address on Mercado Pago payments
- support existing or new address data in payment DTOs
- persist addresses with new `Endereco` entity

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68af963b025083279c2c2e518b3b0d53