### PR TITLE
Add endpoint to fetch fornecedores by UUID list

### DIFF
--- a/src/main/java/com/example/demo/controller/FornecedorController.java
+++ b/src/main/java/com/example/demo/controller/FornecedorController.java
@@ -11,6 +11,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Fornecedores")
@@ -40,6 +41,12 @@ public class FornecedorController {
     @PreAuthorize("hasAnyRole('MASTER','ADMIN')")
     public ResponseEntity<ApiReturn<FornecedorDTO>> buscar(@PathVariable UUID uuid) {
         return ResponseEntity.ok(ApiReturn.of(service.findByUuid(uuid)));
+    }
+
+    @PostMapping("/uuids")
+    @PreAuthorize("hasAnyRole('MASTER','ADMIN')")
+    public ResponseEntity<ApiReturn<List<FornecedorDTO>>> buscarPorUuids(@RequestBody List<UUID> uuids) {
+        return ResponseEntity.ok(ApiReturn.of(service.findByUuids(uuids)));
     }
 
     @PutMapping("/{uuid}")

--- a/src/main/java/com/example/demo/service/FornecedorService.java
+++ b/src/main/java/com/example/demo/service/FornecedorService.java
@@ -18,7 +18,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class FornecedorService {
@@ -77,6 +79,12 @@ public class FornecedorService {
         Fornecedor entity = repository.findById(uuid)
                 .orElseThrow(() -> new ApiException("Fornecedor não encontrado"));
         return mapper.toDto(entity);
+    }
+
+    public List<FornecedorDTO> findByUuids(List<UUID> uuids) {
+        return repository.findAllById(uuids).stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- add service method to retrieve suppliers by a list of UUIDs
- expose `/fornecedores/uuids` POST endpoint returning matching suppliers

## Testing
- `./mvnw -q test` *(fails: wget unable to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_68afa9e7f3008327b4dcf9c4b8654bd8